### PR TITLE
Migrate Ant Design from v4 to v5

### DIFF
--- a/chat-app-front/package-lock.json
+++ b/chat-app-front/package-lock.json
@@ -8,9 +8,9 @@
       "name": "chat-app-front",
       "version": "0.1.0",
       "dependencies": {
-        "@ant-design/icons": "^4.7.0",
+        "@ant-design/icons": "^6.0.1",
         "@apollo/client": "^3.6.9",
-        "antd": "^4.21.7",
+        "antd": "^5.27.3",
         "graphql": "^16.5.0",
         "graphql-ws": "^5.9.1",
         "react": "^18.3.1",
@@ -58,25 +58,67 @@
       }
     },
     "node_modules/@ant-design/colors": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-6.0.0.tgz",
-      "integrity": "sha512-qAZRvPzfdWHtfameEGP2Qvuf838NhergR35o+EuVyB5XvSA98xod5r4utvi4TJ3ywmevm290g9nsCG5MryrdWQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-8.0.0.tgz",
+      "integrity": "sha512-6YzkKCw30EI/E9kHOIXsQDHmMvTllT8STzjMb4K2qzit33RW2pqCJP0sk+hidBntXxE+Vz4n1+RvCTfBw6OErw==",
+      "license": "MIT",
       "dependencies": {
-        "@ctrl/tinycolor": "^3.4.0"
+        "@ant-design/fast-color": "^3.0.0"
+      }
+    },
+    "node_modules/@ant-design/cssinjs": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-1.24.0.tgz",
+      "integrity": "sha512-K4cYrJBsgvL+IoozUXYjbT6LHHNt+19a9zkvpBPxLjFHas1UpPM2A5MlhROb0BT8N8WoavM5VsP9MeSeNK/3mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.11.1",
+        "@emotion/hash": "^0.8.0",
+        "@emotion/unitless": "^0.7.5",
+        "classnames": "^2.3.1",
+        "csstype": "^3.1.3",
+        "rc-util": "^5.35.0",
+        "stylis": "^4.3.4"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/@ant-design/cssinjs-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs-utils/-/cssinjs-utils-1.1.3.tgz",
+      "integrity": "sha512-nOoQMLW1l+xR1Co8NFVYiP8pZp3VjIIzqV6D6ShYF2ljtdwWJn5WSsH+7kvCktXL/yhEtWURKOfH5Xz/gzlwsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ant-design/cssinjs": "^1.21.0",
+        "@babel/runtime": "^7.23.2",
+        "rc-util": "^5.38.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@ant-design/fast-color": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/fast-color/-/fast-color-3.0.0.tgz",
+      "integrity": "sha512-eqvpP7xEDm2S7dUzl5srEQCBTXZMmY3ekf97zI+M2DHOYyKdJGH0qua0JACHTqbkRnD/KHFQP9J1uMJ/XWVzzA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.x"
       }
     },
     "node_modules/@ant-design/icons": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-4.8.3.tgz",
-      "integrity": "sha512-HGlIQZzrEbAhpJR6+IGdzfbPym94Owr6JZkJ2QCCnOkPVIWMO2xgIVcOKnl8YcpijIo39V7l2qQL5fmtw56cMw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-6.0.1.tgz",
+      "integrity": "sha512-BsAoYa8NTwh5GfpziqStAyWHNyp8vkc9PkuIR/Cu8O8WkhRzrpx260zd5ygsXMhQEGtfGGFjdAG0DfjhGBOBHw==",
       "license": "MIT",
       "dependencies": {
-        "@ant-design/colors": "^6.0.0",
-        "@ant-design/icons-svg": "^4.3.0",
-        "@babel/runtime": "^7.11.2",
-        "classnames": "^2.2.6",
-        "lodash": "^4.17.15",
-        "rc-util": "^5.9.4"
+        "@ant-design/colors": "^8.0.0",
+        "@ant-design/icons-svg": "^4.4.0",
+        "@rc-component/util": "^1.2.1",
+        "classnames": "^2.2.6"
       },
       "engines": {
         "node": ">=8"
@@ -93,15 +135,16 @@
       "license": "MIT"
     },
     "node_modules/@ant-design/react-slick": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-0.29.2.tgz",
-      "integrity": "sha512-kgjtKmkGHa19FW21lHnAfyyH9AAoh35pBdcJ53rHmQ3O+cfFHGHnUbj/HFrRNJ5vIts09FKJVAD8RpaC+RaWfA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-1.1.2.tgz",
+      "integrity": "sha512-EzlvzE6xQUBrZuuhSAFTdsr4P2bBBHGZwKFemEfq8gIGyIQCxalYfZW/T2ORbtQx5rU69o+WycP3exY/7T1hGA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.4",
         "classnames": "^2.2.5",
         "json2mq": "^0.2.0",
-        "lodash": "^4.17.21",
-        "resize-observer-polyfill": "^1.5.1"
+        "resize-observer-polyfill": "^1.5.1",
+        "throttle-debounce": "^5.0.0"
       },
       "peerDependencies": {
         "react": ">=16.9.0"
@@ -620,13 +663,17 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "node_modules/@ctrl/tinycolor": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.4.1.tgz",
-      "integrity": "sha512-ej5oVy6lykXsvieQtqZxCOaLT+xD4+QNarq78cIYISHmZXshCvROLudpQN3lfL8G0NL7plMSSK+zlyvCaIJ4Iw==",
-      "engines": {
-        "node": ">=10"
-      }
+    "node_modules/@emotion/hash": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.9",
@@ -1737,6 +1784,187 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@rc-component/async-validator": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@rc-component/async-validator/-/async-validator-5.0.4.tgz",
+      "integrity": "sha512-qgGdcVIF604M9EqjNF0hbUTz42bz/RDtxWdWuU5EQe3hi7M8ob54B6B35rOsvX5eSvIHIzT9iH1R3n+hk3CGfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.4"
+      },
+      "engines": {
+        "node": ">=14.x"
+      }
+    },
+    "node_modules/@rc-component/color-picker": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/color-picker/-/color-picker-2.0.1.tgz",
+      "integrity": "sha512-WcZYwAThV/b2GISQ8F+7650r5ZZJ043E57aVBFkQ+kSY4C6wdofXgB0hBx+GPGpIU0Z81eETNoDUJMr7oy/P8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@ant-design/fast-color": "^2.0.6",
+        "@babel/runtime": "^7.23.6",
+        "classnames": "^2.2.6",
+        "rc-util": "^5.38.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/color-picker/node_modules/@ant-design/fast-color": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@ant-design/fast-color/-/fast-color-2.0.6.tgz",
+      "integrity": "sha512-y2217gk4NqL35giHl72o6Zzqji9O7vHh9YmhUVkPtAOpoTCH4uWxo/pr4VE8t0+ChEPs0qo4eJRC5Q1eXWo3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=8.x"
+      }
+    },
+    "node_modules/@rc-component/context": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/context/-/context-1.4.0.tgz",
+      "integrity": "sha512-kFcNxg9oLRMoL3qki0OMxK+7g5mypjgaaJp/pkOis/6rVxma9nJBF/8kCIuTYHUQNr0ii7MxqE33wirPZLJQ2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "rc-util": "^5.27.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/mini-decimal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/mini-decimal/-/mini-decimal-1.1.0.tgz",
+      "integrity": "sha512-jS4E7T9Li2GuYwI6PyiVXmxTiM6b07rlD9Ge8uGZSCz3WlzcG5ZK7g5bbuKNeZ9pgUuPK/5guV781ujdVpm4HQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.0"
+      },
+      "engines": {
+        "node": ">=8.x"
+      }
+    },
+    "node_modules/@rc-component/mutate-observer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/mutate-observer/-/mutate-observer-1.1.0.tgz",
+      "integrity": "sha512-QjrOsDXQusNwGZPf4/qRQasg7UFEj06XiCJ8iuiq/Io7CrHrgVi6Uuetw60WAMG1799v+aM8kyc+1L/GBbHSlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.0",
+        "classnames": "^2.3.2",
+        "rc-util": "^5.24.4"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/portal": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-1.1.2.tgz",
+      "integrity": "sha512-6f813C0IsasTZms08kfA8kPAGxbbkYToa8ALaiDIGGECU4i9hj8Plgbx0sNJDrey3EtHO30hmdaxtT0138xZcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.0",
+        "classnames": "^2.3.2",
+        "rc-util": "^5.24.4"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/qrcode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/qrcode/-/qrcode-1.0.0.tgz",
+      "integrity": "sha512-L+rZ4HXP2sJ1gHMGHjsg9jlYBX/SLN2D6OxP9Zn3qgtpMWtO2vUfxVFwiogHpAIqs54FnALxraUy/BCO1yRIgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.7",
+        "classnames": "^2.3.2",
+        "rc-util": "^5.38.0"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/tour": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/tour/-/tour-1.15.1.tgz",
+      "integrity": "sha512-Tr2t7J1DKZUpfJuDZWHxyxWpfmj8EZrqSgyMZ+BCdvKZ6r1UDsfU46M/iWAAFBy961Ssfom2kv5f3UcjIL2CmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.0",
+        "@rc-component/portal": "^1.0.0-9",
+        "@rc-component/trigger": "^2.0.0",
+        "classnames": "^2.3.2",
+        "rc-util": "^5.24.4"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/trigger": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-2.3.0.tgz",
+      "integrity": "sha512-iwaxZyzOuK0D7lS+0AQEtW52zUWxoGqTGkke3dRyb8pYiShmRpCjB/8TzPI4R6YySCH7Vm9BZj/31VPiiQTLBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "@rc-component/portal": "^1.1.0",
+        "classnames": "^2.3.2",
+        "rc-motion": "^2.0.0",
+        "rc-resize-observer": "^1.3.1",
+        "rc-util": "^5.44.0"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/util": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/util/-/util-1.3.0.tgz",
+      "integrity": "sha512-hfXE04CVsxI/slmWKeSh6du7sSKpbvVdVEZCa8A+2QWDlL97EsCYme2c3ZWLn1uC9FR21JoewlrhUPWO4QgO8w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-mobile": "^5.0.0",
+        "react-is": "^18.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/util/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.34",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.34.tgz",
@@ -2767,54 +2995,60 @@
       }
     },
     "node_modules/antd": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/antd/-/antd-4.22.4.tgz",
-      "integrity": "sha512-u7l68PhSJMxyZmCNw+jwaeurSAaE+bU+lB0SPRHLfOFJR6xRudntvRoQdiEFOD5FZ3eeqz4lYQ3RZZRIarmceg==",
+      "version": "5.27.3",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-5.27.3.tgz",
+      "integrity": "sha512-Jewp1ek1iyqoAyjWyPgzc2kioZ+7S3jh39a+tld/j4ucnuf/cBk4omfyIdhLz49pVNsaEcRp5LtJOSQPFwPgpA==",
+      "license": "MIT",
       "dependencies": {
-        "@ant-design/colors": "^6.0.0",
-        "@ant-design/icons": "^4.7.0",
-        "@ant-design/react-slick": "~0.29.1",
-        "@babel/runtime": "^7.18.3",
-        "@ctrl/tinycolor": "^3.4.0",
-        "classnames": "^2.2.6",
-        "copy-to-clipboard": "^3.2.0",
-        "lodash": "^4.17.21",
-        "memoize-one": "^6.0.0",
-        "moment": "^2.29.2",
-        "rc-cascader": "~3.6.0",
-        "rc-checkbox": "~2.3.0",
-        "rc-collapse": "~3.3.0",
-        "rc-dialog": "~8.9.0",
-        "rc-drawer": "~5.1.0-alpha.1",
-        "rc-dropdown": "~4.0.0",
-        "rc-field-form": "~1.27.0",
-        "rc-image": "~5.7.0",
-        "rc-input": "~0.0.1-alpha.5",
-        "rc-input-number": "~7.3.5",
-        "rc-mentions": "~1.9.1",
-        "rc-menu": "~9.6.0",
-        "rc-motion": "^2.6.1",
-        "rc-notification": "~4.6.0",
-        "rc-pagination": "~3.1.17",
-        "rc-picker": "~2.6.10",
-        "rc-progress": "~3.3.2",
-        "rc-rate": "~2.9.0",
-        "rc-resize-observer": "^1.2.0",
-        "rc-segmented": "~2.1.0",
-        "rc-select": "~14.1.1",
-        "rc-slider": "~10.0.0",
-        "rc-steps": "~4.1.0",
-        "rc-switch": "~3.2.0",
-        "rc-table": "~7.25.3",
-        "rc-tabs": "~11.16.0",
-        "rc-textarea": "~0.3.0",
-        "rc-tooltip": "~5.2.0",
-        "rc-tree": "~5.6.5",
-        "rc-tree-select": "~5.4.0",
-        "rc-trigger": "^5.2.10",
-        "rc-upload": "~4.3.0",
-        "rc-util": "^5.22.5",
-        "scroll-into-view-if-needed": "^2.2.25"
+        "@ant-design/colors": "^7.2.1",
+        "@ant-design/cssinjs": "^1.23.0",
+        "@ant-design/cssinjs-utils": "^1.1.3",
+        "@ant-design/fast-color": "^2.0.6",
+        "@ant-design/icons": "^5.6.1",
+        "@ant-design/react-slick": "~1.1.2",
+        "@babel/runtime": "^7.26.0",
+        "@rc-component/color-picker": "~2.0.1",
+        "@rc-component/mutate-observer": "^1.1.0",
+        "@rc-component/qrcode": "~1.0.0",
+        "@rc-component/tour": "~1.15.1",
+        "@rc-component/trigger": "^2.3.0",
+        "classnames": "^2.5.1",
+        "copy-to-clipboard": "^3.3.3",
+        "dayjs": "^1.11.11",
+        "rc-cascader": "~3.34.0",
+        "rc-checkbox": "~3.5.0",
+        "rc-collapse": "~3.9.0",
+        "rc-dialog": "~9.6.0",
+        "rc-drawer": "~7.3.0",
+        "rc-dropdown": "~4.2.1",
+        "rc-field-form": "~2.7.0",
+        "rc-image": "~7.12.0",
+        "rc-input": "~1.8.0",
+        "rc-input-number": "~9.5.0",
+        "rc-mentions": "~2.20.0",
+        "rc-menu": "~9.16.1",
+        "rc-motion": "^2.9.5",
+        "rc-notification": "~5.6.4",
+        "rc-pagination": "~5.1.0",
+        "rc-picker": "~4.11.3",
+        "rc-progress": "~4.0.0",
+        "rc-rate": "~2.13.1",
+        "rc-resize-observer": "^1.4.3",
+        "rc-segmented": "~2.7.0",
+        "rc-select": "~14.16.8",
+        "rc-slider": "~11.1.8",
+        "rc-steps": "~6.0.1",
+        "rc-switch": "~4.1.0",
+        "rc-table": "~7.52.6",
+        "rc-tabs": "~15.7.0",
+        "rc-textarea": "~1.10.2",
+        "rc-tooltip": "~6.4.0",
+        "rc-tree": "~5.13.1",
+        "rc-tree-select": "~5.27.0",
+        "rc-upload": "~4.9.2",
+        "rc-util": "^5.44.4",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "throttle-debounce": "^5.0.2"
       },
       "funding": {
         "type": "opencollective",
@@ -2823,6 +3057,47 @@
       "peerDependencies": {
         "react": ">=16.9.0",
         "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/antd/node_modules/@ant-design/colors": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-7.2.1.tgz",
+      "integrity": "sha512-lCHDcEzieu4GA3n8ELeZ5VQ8pKQAWcGGLRTQ50aQM2iqPpq2evTxER84jfdPvsPAtEcZ7m44NI45edFMo8oOYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ant-design/fast-color": "^2.0.6"
+      }
+    },
+    "node_modules/antd/node_modules/@ant-design/fast-color": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@ant-design/fast-color/-/fast-color-2.0.6.tgz",
+      "integrity": "sha512-y2217gk4NqL35giHl72o6Zzqji9O7vHh9YmhUVkPtAOpoTCH4uWxo/pr4VE8t0+ChEPs0qo4eJRC5Q1eXWo3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=8.x"
+      }
+    },
+    "node_modules/antd/node_modules/@ant-design/icons": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.6.1.tgz",
+      "integrity": "sha512-0/xS39c91WjPAZOWsvi1//zjx6kAp4kxWwctR6kuU6p133w8RU0D2dSCvZC19uQyharg/sAvYxGYWl01BbZZfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ant-design/colors": "^7.0.0",
+        "@ant-design/icons-svg": "^4.4.0",
+        "@babel/runtime": "^7.24.8",
+        "classnames": "^2.2.6",
+        "rc-util": "^5.31.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
       }
     },
     "node_modules/anymatch": {
@@ -2855,18 +3130,6 @@
       "engines": {
         "node": ">=6.0"
       }
-    },
-    "node_modules/array-tree-filter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-tree-filter/-/array-tree-filter-2.1.0.tgz",
-      "integrity": "sha512-4ROwICNlNw/Hqa9v+rk5h22KjmzB1JGTMVKP2AKJBOCgb0yL0ASf0+YvCcLNNwquOHNX48jkeZIJ3a+oOQqKcw==",
-      "license": "MIT"
-    },
-    "node_modules/async-validator": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/async-validator/-/async-validator-4.2.5.tgz",
-      "integrity": "sha512-7HhHjtERjqlNbZtqNqy2rckN/SpOOlmDliet+lP7k+eKZEjPk3DgyeU9lIXLdeLz0uBbbVp+9Qdow9wJWgwwfg==",
-      "license": "MIT"
     },
     "node_modules/babel-jest": {
       "version": "28.1.3",
@@ -3114,9 +3377,10 @@
       "dev": true
     },
     "node_modules/classnames": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
     },
     "node_modules/cliui": {
       "version": "7.0.4",
@@ -3164,9 +3428,10 @@
       "dev": true
     },
     "node_modules/compute-scroll-into-view": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz",
-      "integrity": "sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -3184,9 +3449,10 @@
       }
     },
     "node_modules/copy-to-clipboard": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.2.tgz",
-      "integrity": "sha512-Vme1Z6RUDzrb6xAI7EZlVZ5uvOk2F//GaxKUxajDqm9LhOVM1inxNAD2vy+UZDYsd0uyA9s7b3/FVZPSxqrCfg==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "license": "MIT",
       "dependencies": {
         "toggle-selection": "^1.0.6"
       }
@@ -3213,26 +3479,10 @@
       "dev": true
     },
     "node_modules/csstype": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
-      "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==",
-      "dev": true
-    },
-    "node_modules/date-fns": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0"
-      },
-      "engines": {
-        "node": ">=0.11"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
-      }
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
     },
     "node_modules/dayjs": {
       "version": "1.11.18",
@@ -3302,12 +3552,6 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz",
       "integrity": "sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==",
       "dev": true
-    },
-    "node_modules/dom-align": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.12.4.tgz",
-      "integrity": "sha512-R8LUSEay/68zE5c8/3BDxiTEvgb4xZTF0RKmAHfiEVN3klfIpXfi2/QCoiWPccVQ0J/ZGdz9OjzL4uJEP/MRAw==",
-      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.214",
@@ -4244,6 +4488,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-mobile": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-5.0.0.tgz",
+      "integrity": "sha512-Tz/yndySvLAEXh+Uk8liFCxOwVH6YutuR74utvOcu7I9Di+DwM0mtdPVZNaVvvBUM2OXxne/NhOs1zAO7riusQ==",
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -5265,6 +5515,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
       "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
+      "license": "MIT",
       "dependencies": {
         "string-convert": "^0.2.0"
       }
@@ -5345,7 +5596,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -5407,11 +5659,6 @@
         "tmpl": "1.0.5"
       }
     },
-    "node_modules/memoize-one": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
-      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
-    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -5468,14 +5715,6 @@
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
       "engines": {
         "node": "*"
       }
@@ -5912,35 +6151,17 @@
       ],
       "license": "MIT"
     },
-    "node_modules/rc-align": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.15.tgz",
-      "integrity": "sha512-wqJtVH60pka/nOX7/IspElA8gjPNQKIx/ZqJ6heATCkXpe1Zg4cPVrMD2vC96wjsFFL8WsmhPbx9tdMo1qqlIA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "dom-align": "^1.7.0",
-        "rc-util": "^5.26.0",
-        "resize-observer-polyfill": "^1.5.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
     "node_modules/rc-cascader": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-3.6.2.tgz",
-      "integrity": "sha512-sf2otpazlROTzkD3nZVfIzXmfBLiEOBTXA5wxozGXBpS902McDpvF0bdcYBu5hN+rviEAm6Mh9cLXNQ1Ty8wKQ==",
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-3.34.0.tgz",
+      "integrity": "sha512-KpXypcvju9ptjW9FaN2NFcA2QH9E9LHKq169Y0eWtH4e/wHQ5Wh5qZakAgvb8EKZ736WZ3B0zLLOBsrsja5Dag==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "array-tree-filter": "^2.1.0",
+        "@babel/runtime": "^7.25.7",
         "classnames": "^2.3.1",
-        "rc-select": "~14.1.0",
-        "rc-tree": "~5.6.3",
-        "rc-util": "^5.6.1"
+        "rc-select": "~14.16.2",
+        "rc-tree": "~5.13.0",
+        "rc-util": "^5.43.0"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -5948,13 +6169,14 @@
       }
     },
     "node_modules/rc-checkbox": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/rc-checkbox/-/rc-checkbox-2.3.2.tgz",
-      "integrity": "sha512-afVi1FYiGv1U0JlpNH/UaEXdh6WUJjcWokj/nUN2TgG80bfG+MDdbfHKlLcNNba94mbjy2/SXJ1HDgrOkXGAjg==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/rc-checkbox/-/rc-checkbox-3.5.0.tgz",
+      "integrity": "sha512-aOAQc3E98HteIIsSqm6Xk2FPKIER6+5vyEFMZfo73TqM+VVAIqOkHoPjgKLqSNtVLWScoaM7vY2ZrGEheI79yg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.1"
+        "classnames": "^2.3.2",
+        "rc-util": "^5.25.2"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -5962,16 +6184,15 @@
       }
     },
     "node_modules/rc-collapse": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-3.3.1.tgz",
-      "integrity": "sha512-cOJfcSe3R8vocrF8T+PgaHDrgeA1tX+lwfhwSj60NX9QVRidsILIbRNDLD6nAzmcvVC5PWiIRiR4S1OobxdhCg==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-3.9.0.tgz",
+      "integrity": "sha512-swDdz4QZ4dFTo4RAUMLL50qP0EY62N2kvmk2We5xYdRwcRn8WcYtuetCJpwpaCbUfUt5+huLpVxhvmnK+PHrkA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
         "rc-motion": "^2.3.4",
-        "rc-util": "^5.2.1",
-        "shallowequal": "^1.1.0"
+        "rc-util": "^5.27.0"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -5979,12 +6200,13 @@
       }
     },
     "node_modules/rc-dialog": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-8.9.0.tgz",
-      "integrity": "sha512-Cp0tbJnrvPchJfnwIvOMWmJ4yjX3HWFatO6oBFD1jx8QkgsQCR0p8nUWAKdd3seLJhEC39/v56kZaEjwp9muoQ==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-9.6.0.tgz",
+      "integrity": "sha512-ApoVi9Z8PaCQg6FsUzS8yvBEQy0ZL2PkuvAgrmohPkN3okps5WZ5WQWPc1RNuiOKaAYv8B97ACdsFU5LizzCqg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
+        "@rc-component/portal": "^1.0.0-8",
         "classnames": "^2.2.6",
         "rc-motion": "^2.3.0",
         "rc-util": "^5.21.0"
@@ -5995,14 +6217,16 @@
       }
     },
     "node_modules/rc-drawer": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/rc-drawer/-/rc-drawer-5.1.0.tgz",
-      "integrity": "sha512-pU3Tsn99pxGdYowXehzZbdDVE+4lDXSGb7p8vA9mSmr569oc2Izh4Zw5vLKSe/Xxn2p5MSNbLVqD4tz+pK6SOw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/rc-drawer/-/rc-drawer-7.3.0.tgz",
+      "integrity": "sha512-DX6CIgiBWNpJIMGFO8BAISFkxiuKitoizooj4BDyee8/SnBn0zwO2FHrNDpqqepj0E/TFTDpmEBCyFuTgC7MOg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.10.1",
+        "@babel/runtime": "^7.23.9",
+        "@rc-component/portal": "^1.1.1",
         "classnames": "^2.2.6",
         "rc-motion": "^2.6.1",
-        "rc-util": "^5.21.2"
+        "rc-util": "^5.38.1"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -6010,15 +6234,15 @@
       }
     },
     "node_modules/rc-dropdown": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-4.0.1.tgz",
-      "integrity": "sha512-OdpXuOcme1rm45cR0Jzgfl1otzmU4vuBVb+etXM8vcaULGokAKVpKlw8p6xzspG7jGd/XxShvq+N3VNEfk/l5g==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-4.2.1.tgz",
+      "integrity": "sha512-YDAlXsPv3I1n42dv1JpdM7wJ+gSUBfeyPK59ZpBD9jQhK9jVuxpjj3NmWQHOBceA1zEPVX84T2wbdb2SD0UjmA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
+        "@rc-component/trigger": "^2.0.0",
         "classnames": "^2.2.6",
-        "rc-trigger": "^5.3.1",
-        "rc-util": "^5.17.0"
+        "rc-util": "^5.44.1"
       },
       "peerDependencies": {
         "react": ">=16.11.0",
@@ -6026,14 +6250,14 @@
       }
     },
     "node_modules/rc-field-form": {
-      "version": "1.27.4",
-      "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-1.27.4.tgz",
-      "integrity": "sha512-PQColQnZimGKArnOh8V2907+VzDCXcqtFvHgevDLtqWc/P7YASb/FqntSmdS8q3VND5SHX3Y1vgMIzY22/f/0Q==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-2.7.0.tgz",
+      "integrity": "sha512-hgKsCay2taxzVnBPZl+1n4ZondsV78G++XVsMIJCAoioMjlMQR9YwAp7JZDIECzIu2Z66R+f4SFIRrO2DjDNAA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.0",
-        "async-validator": "^4.1.0",
-        "rc-util": "^5.8.0"
+        "@rc-component/async-validator": "^5.0.3",
+        "rc-util": "^5.32.2"
       },
       "engines": {
         "node": ">=8.x"
@@ -6044,15 +6268,17 @@
       }
     },
     "node_modules/rc-image": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/rc-image/-/rc-image-5.7.1.tgz",
-      "integrity": "sha512-QyMfdhoUfb5W14plqXSisaYwpdstcLYnB0MjX5ccIK2rydQM9sDPuekQWu500DDGR2dBaIF5vx9XbWkNFK17Fg==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/rc-image/-/rc-image-7.12.0.tgz",
+      "integrity": "sha512-cZ3HTyyckPnNnUb9/DRqduqzLfrQRyi+CdHjdqgsyDpI3Ln5UX1kXnAhPBSJj9pVRzwRFgqkN7p9b6HBDjmu/Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
+        "@rc-component/portal": "^1.0.2",
         "classnames": "^2.2.6",
-        "rc-dialog": "~8.9.0",
-        "rc-util": "^5.0.6"
+        "rc-dialog": "~9.6.0",
+        "rc-motion": "^2.6.2",
+        "rc-util": "^5.34.1"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -6060,9 +6286,9 @@
       }
     },
     "node_modules/rc-input": {
-      "version": "0.0.1-alpha.7",
-      "resolved": "https://registry.npmjs.org/rc-input/-/rc-input-0.0.1-alpha.7.tgz",
-      "integrity": "sha512-eozaqpCYWSY5LBMwlHgC01GArkVEP+XlJ84OMvdkwUnJBSv83Yxa15pZpn7vACAj84uDC4xOA2CoFdbLuqB08Q==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/rc-input/-/rc-input-1.8.0.tgz",
+      "integrity": "sha512-KXvaTbX+7ha8a/k+eg6SYRVERK0NddX8QX7a7AnRvUa/rEH0CNMlpcBzBkhI0wp2C8C4HlMoYl8TImSN+fuHKA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
@@ -6075,14 +6301,16 @@
       }
     },
     "node_modules/rc-input-number": {
-      "version": "7.3.11",
-      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-7.3.11.tgz",
-      "integrity": "sha512-aMWPEjFeles6PQnMqP5eWpxzsvHm9rh1jQOWXExUEIxhX62Fyl/ptifLHOn17+waDG1T/YUb6flfJbvwRhHrbA==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-9.5.0.tgz",
+      "integrity": "sha512-bKaEvB5tHebUURAEXw35LDcnRZLq3x1k7GxfAqBMzmpHkDGzjAtnUL8y4y5N15rIFIg5IJgwr211jInl3cipag==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
+        "@rc-component/mini-decimal": "^1.0.1",
         "classnames": "^2.2.5",
-        "rc-util": "^5.23.0"
+        "rc-input": "~1.8.0",
+        "rc-util": "^5.40.1"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -6090,17 +6318,18 @@
       }
     },
     "node_modules/rc-mentions": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-1.9.2.tgz",
-      "integrity": "sha512-uxb/lzNnEGmvraKWNGE6KXMVXvt8RQv9XW8R0Dqi3hYsyPiAZeHRCHQKdLARuk5YBhFhZ6ga55D/8XuY367g3g==",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-2.20.0.tgz",
+      "integrity": "sha512-w8HCMZEh3f0nR8ZEd466ATqmXFCMGMN5UFCzEUL0bM/nGw/wOS2GgRzKBcm19K++jDyuWCOJOdgcKGXU3fXfbQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.10.1",
+        "@babel/runtime": "^7.22.5",
+        "@rc-component/trigger": "^2.0.0",
         "classnames": "^2.2.6",
-        "rc-menu": "~9.6.0",
-        "rc-textarea": "^0.3.0",
-        "rc-trigger": "^5.0.4",
-        "rc-util": "^5.22.5"
+        "rc-input": "~1.8.0",
+        "rc-menu": "~9.16.0",
+        "rc-textarea": "~1.10.0",
+        "rc-util": "^5.34.1"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -6108,18 +6337,17 @@
       }
     },
     "node_modules/rc-menu": {
-      "version": "9.6.4",
-      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.6.4.tgz",
-      "integrity": "sha512-6DiNAjxjVIPLZXHffXxxcyE15d4isRL7iQ1ru4MqYDH2Cqc5bW96wZOdMydFtGLyDdnmEQ9jVvdCE9yliGvzkw==",
+      "version": "9.16.1",
+      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.16.1.tgz",
+      "integrity": "sha512-ghHx6/6Dvp+fw8CJhDUHFHDJ84hJE3BXNCzSgLdmNiFErWSOaZNsihDAsKq9ByTALo/xkNIwtDFGIl6r+RPXBg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
+        "@rc-component/trigger": "^2.0.0",
         "classnames": "2.x",
         "rc-motion": "^2.4.3",
-        "rc-overflow": "^1.2.0",
-        "rc-trigger": "^5.1.2",
-        "rc-util": "^5.12.0",
-        "shallowequal": "^1.1.0"
+        "rc-overflow": "^1.3.1",
+        "rc-util": "^5.27.0"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -6142,14 +6370,14 @@
       }
     },
     "node_modules/rc-notification": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-4.6.1.tgz",
-      "integrity": "sha512-NSmFYwrrdY3+un1GvDAJQw62Xi9LNMSsoQyo95tuaYrcad5Bn9gJUL8AREufRxSQAQnr64u3LtP3EUyLYT6bhw==",
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-5.6.4.tgz",
+      "integrity": "sha512-KcS4O6B4qzM3KH7lkwOB7ooLPZ4b6J+VMmQgT51VZCeEcmghdeR4IrMcFq0LG+RPdnbe/ArT086tGM8Snimgiw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
-        "rc-motion": "^2.2.0",
+        "rc-motion": "^2.9.0",
         "rc-util": "^5.20.1"
       },
       "engines": {
@@ -6177,13 +6405,14 @@
       }
     },
     "node_modules/rc-pagination": {
-      "version": "3.1.17",
-      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-3.1.17.tgz",
-      "integrity": "sha512-/BQ5UxcBnW28vFAcP2hfh+Xg15W0QZn8TWYwdCApchMH1H0CxiaUUcULP8uXcFM1TygcdKWdt3JqsL9cTAfdkQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-5.1.0.tgz",
+      "integrity": "sha512-8416Yip/+eclTFdHXLKTxZvn70duYVGTvUUWbckCCZoIl3jagqke3GLsFrMs0bsQBikiYpZLD9206Ej4SOdOXQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.1"
+        "classnames": "^2.3.2",
+        "rc-util": "^5.38.0"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -6191,32 +6420,48 @@
       }
     },
     "node_modules/rc-picker": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-2.6.11.tgz",
-      "integrity": "sha512-INJ7ULu+Kj4UgqbcqE8Q+QpMw55xFf9kkyLBHJFk0ihjJpAV4glialRfqHE7k4KX2BWYPQfpILwhwR14x2EiRQ==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-4.11.3.tgz",
+      "integrity": "sha512-MJ5teb7FlNE0NFHTncxXQ62Y5lytq6sh5nUw0iH8OkHL/TjARSEvSHpr940pWgjGANpjCwyMdvsEV55l5tYNSg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.10.1",
+        "@babel/runtime": "^7.24.7",
+        "@rc-component/trigger": "^2.0.0",
         "classnames": "^2.2.1",
-        "date-fns": "2.x",
-        "dayjs": "1.x",
-        "moment": "^2.24.0",
-        "rc-trigger": "^5.0.4",
-        "rc-util": "^5.4.0",
-        "shallowequal": "^1.1.0"
+        "rc-overflow": "^1.3.2",
+        "rc-resize-observer": "^1.4.0",
+        "rc-util": "^5.43.0"
       },
       "engines": {
         "node": ">=8.x"
       },
       "peerDependencies": {
+        "date-fns": ">= 2.x",
+        "dayjs": ">= 1.x",
+        "luxon": ">= 3.x",
+        "moment": ">= 2.x",
         "react": ">=16.9.0",
         "react-dom": ">=16.9.0"
+      },
+      "peerDependenciesMeta": {
+        "date-fns": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        }
       }
     },
     "node_modules/rc-progress": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/rc-progress/-/rc-progress-3.3.3.tgz",
-      "integrity": "sha512-MDVNVHzGanYtRy2KKraEaWeZLri2ZHWIRyaE1a9MQ2MuJ09m+Wxj5cfcaoaR6z5iRpHpA59YeUxAlpML8N4PJw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rc-progress/-/rc-progress-4.0.0.tgz",
+      "integrity": "sha512-oofVMMafOCokIUIBnZLNcOZFsABaUw8PPrf1/y0ZBvKZNpOiu5h4AO9vv11Sw0p4Hb3D0yGWuEattcQGtNJ/aw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -6229,9 +6474,9 @@
       }
     },
     "node_modules/rc-rate": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/rc-rate/-/rc-rate-2.9.3.tgz",
-      "integrity": "sha512-2THssUSnRhtqIouQIIXqsZGzRczvp4WsH4WvGuhiwm+LG2fVpDUJliP9O1zeDOZvYfBE/Bup4SgHun/eCkbjgQ==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/rc-rate/-/rc-rate-2.13.1.tgz",
+      "integrity": "sha512-QUhQ9ivQ8Gy7mtMZPAjLbxBt5y9GRp65VcUyGUMF3N3fhiftivPHdpuDIaWIMOTEprAjZPC08bls1dQB+I1F2Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -6263,9 +6508,9 @@
       }
     },
     "node_modules/rc-segmented": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/rc-segmented/-/rc-segmented-2.1.2.tgz",
-      "integrity": "sha512-qGo1bCr83ESXpXVOCXjFe1QJlCAQXyi9KCiy8eX3rIMYlTeJr/ftySIaTnYsitL18SvWf5ZEHsfqIWoX0EMfFQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/rc-segmented/-/rc-segmented-2.7.0.tgz",
+      "integrity": "sha512-liijAjXz+KnTRVnxxXG2sYDGd6iLL7VpGGdR8gwoxAXy2KglviKCxLWZdjKYJzYzGSUwKDSTdYk8brj54Bn5BA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
@@ -6279,18 +6524,18 @@
       }
     },
     "node_modules/rc-select": {
-      "version": "14.1.18",
-      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-14.1.18.tgz",
-      "integrity": "sha512-4JgY3oG2Yz68ECMUSCON7mtxuJvCSj+LJpHEg/AONaaVBxIIrmI/ZTuMJkyojall/X50YdBe5oMKqHHPNiPzEg==",
+      "version": "14.16.8",
+      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-14.16.8.tgz",
+      "integrity": "sha512-NOV5BZa1wZrsdkKaiK7LHRuo5ZjZYMDxPP6/1+09+FB4KoNi8jcG1ZqLE3AVCxEsYMBe65OBx71wFoHRTP3LRg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
+        "@rc-component/trigger": "^2.1.1",
         "classnames": "2.x",
         "rc-motion": "^2.0.1",
-        "rc-overflow": "^1.0.0",
-        "rc-trigger": "^5.0.4",
+        "rc-overflow": "^1.3.1",
         "rc-util": "^5.16.1",
-        "rc-virtual-list": "^3.2.0"
+        "rc-virtual-list": "^3.5.2"
       },
       "engines": {
         "node": ">=8.x"
@@ -6301,15 +6546,14 @@
       }
     },
     "node_modules/rc-slider": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-10.0.1.tgz",
-      "integrity": "sha512-igTKF3zBet7oS/3yNiIlmU8KnZ45npmrmHlUUio8PNbIhzMcsh+oE/r2UD42Y6YD2D/s+kzCQkzQrPD6RY435Q==",
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-11.1.8.tgz",
+      "integrity": "sha512-2gg/72YFSpKP+Ja5AjC5DPL1YnV8DEITDQrcc1eASrUYjl0esptaBVJBh5nLTXCCp15eD8EuGjwezVGSHhs9tQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.5",
-        "rc-util": "^5.18.1",
-        "shallowequal": "^1.1.0"
+        "rc-util": "^5.36.0"
       },
       "engines": {
         "node": ">=8.x"
@@ -6320,14 +6564,14 @@
       }
     },
     "node_modules/rc-steps": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/rc-steps/-/rc-steps-4.1.4.tgz",
-      "integrity": "sha512-qoCqKZWSpkh/b03ASGx1WhpKnuZcRWmvuW+ZUu4mvMdfvFzVxblTwUM+9aBd0mlEUFmt6GW8FXhMpHkK3Uzp3w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rc-steps/-/rc-steps-6.0.1.tgz",
+      "integrity": "sha512-lKHL+Sny0SeHkQKKDJlAjV5oZ8DwCdS2hFhAkIjuQt1/pB81M0cA0ErVFdHq9+jmPmFw1vJB2F5NBzFXLJxV+g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.10.2",
+        "@babel/runtime": "^7.16.7",
         "classnames": "^2.2.3",
-        "rc-util": "^5.0.1"
+        "rc-util": "^5.16.1"
       },
       "engines": {
         "node": ">=8.x"
@@ -6338,14 +6582,14 @@
       }
     },
     "node_modules/rc-switch": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/rc-switch/-/rc-switch-3.2.2.tgz",
-      "integrity": "sha512-+gUJClsZZzvAHGy1vZfnwySxj+MjLlGRyXKXScrtCTcmiYNPzxDFOxdQ/3pK1Kt/0POvwJ/6ALOR8gwdXGhs+A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/rc-switch/-/rc-switch-4.1.0.tgz",
+      "integrity": "sha512-TI8ufP2Az9oEbvyCeVE4+90PDSljGyuwix3fV58p7HV2o4wBnVToEyomJRVyTaZeqNPAp+vqeo4Wnj5u0ZZQBg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.10.1",
+        "@babel/runtime": "^7.21.0",
         "classnames": "^2.2.1",
-        "rc-util": "^5.0.1"
+        "rc-util": "^5.30.0"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -6353,16 +6597,17 @@
       }
     },
     "node_modules/rc-table": {
-      "version": "7.25.3",
-      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.25.3.tgz",
-      "integrity": "sha512-McsLJ2rg8EEpRBRYN4Pf9gT7ZNYnjvF9zrBpUBBbUX/fxk+eGi5ff1iPIhMyiHsH71/BmTUzX9nc9XqupD0nMg==",
+      "version": "7.52.6",
+      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.52.6.tgz",
+      "integrity": "sha512-FxcbhNEFhvg+2bV8KB2Z0RMZj5HFCtiUZU2XuAMwB6Fk3ry2RHtXQmKHpSekG8F480HoSpSmjQoq5/sjLUe6oA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
+        "@rc-component/context": "^1.4.0",
         "classnames": "^2.2.5",
         "rc-resize-observer": "^1.1.0",
-        "rc-util": "^5.22.5",
-        "shallowequal": "^1.1.0"
+        "rc-util": "^5.44.3",
+        "rc-virtual-list": "^3.14.2"
       },
       "engines": {
         "node": ">=8.x"
@@ -6373,17 +6618,18 @@
       }
     },
     "node_modules/rc-tabs": {
-      "version": "11.16.1",
-      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-11.16.1.tgz",
-      "integrity": "sha512-bR7Dap23YyfzZQwtKomhiFEFzZuE7WaKWo+ypNRSGB9PDKSc6tM12VP8LWYkvmmQHthgwP0WRN8nFbSJWuqLYw==",
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-15.7.0.tgz",
+      "integrity": "sha512-ZepiE+6fmozYdWf/9gVp7k56PKHB1YYoDsKeQA1CBlJ/POIhjkcYiv0AGP0w2Jhzftd3AVvZP/K+V+Lpi2ankA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
         "classnames": "2.x",
-        "rc-dropdown": "~4.0.0",
-        "rc-menu": "~9.6.0",
+        "rc-dropdown": "~4.2.0",
+        "rc-menu": "~9.16.0",
+        "rc-motion": "^2.6.2",
         "rc-resize-observer": "^1.0.0",
-        "rc-util": "^5.5.0"
+        "rc-util": "^5.34.1"
       },
       "engines": {
         "node": ">=8.x"
@@ -6394,16 +6640,16 @@
       }
     },
     "node_modules/rc-textarea": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/rc-textarea/-/rc-textarea-0.3.7.tgz",
-      "integrity": "sha512-yCdZ6binKmAQB13hc/oehh0E/QRwoPP1pjF21aHBxlgXO3RzPF6dUu4LG2R4FZ1zx/fQd2L1faktulrXOM/2rw==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/rc-textarea/-/rc-textarea-1.10.2.tgz",
+      "integrity": "sha512-HfaeXiaSlpiSp0I/pvWpecFEHpVysZ9tpDLNkxQbMvMz6gsr7aVZ7FpWP9kt4t7DB+jJXesYS0us1uPZnlRnwQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.1",
+        "rc-input": "~1.8.0",
         "rc-resize-observer": "^1.0.0",
-        "rc-util": "^5.7.0",
-        "shallowequal": "^1.1.0"
+        "rc-util": "^5.27.0"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -6411,14 +6657,15 @@
       }
     },
     "node_modules/rc-tooltip": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-5.2.2.tgz",
-      "integrity": "sha512-jtQzU/18S6EI3lhSGoDYhPqNpWajMtS5VV/ld1LwyfrDByQpYmw/LW6U7oFXXLukjfDHQ7Ju705A82PRNFWYhg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-6.4.0.tgz",
+      "integrity": "sha512-kqyivim5cp8I5RkHmpsp1Nn/Wk+1oeloMv9c7LXNgDxUpGm+RbXJGL+OPvDlcRnx9DBeOe4wyOIl4OKUERyH1g==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
+        "@rc-component/trigger": "^2.0.0",
         "classnames": "^2.3.1",
-        "rc-trigger": "^5.0.0"
+        "rc-util": "^5.44.3"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -6426,16 +6673,16 @@
       }
     },
     "node_modules/rc-tree": {
-      "version": "5.6.9",
-      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-5.6.9.tgz",
-      "integrity": "sha512-si8aGuWQ2/sh2Ibk+WdUdDeAxoviT/+kDY+NLtJ+RhqfySqPFqWM5uHTwgFRrWUvKCqEeE/PjCYuuhHrK7Y7+A==",
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-5.13.1.tgz",
+      "integrity": "sha512-FNhIefhftobCdUJshO7M8uZTA9F4OPGVXqGfZkkD/5soDeOhwO06T/aKTrg0WD8gRg/pyfq+ql3aMymLHCTC4A==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
         "rc-motion": "^2.0.1",
         "rc-util": "^5.16.1",
-        "rc-virtual-list": "^3.4.8"
+        "rc-virtual-list": "^3.5.1"
       },
       "engines": {
         "node": ">=10.x"
@@ -6446,46 +6693,26 @@
       }
     },
     "node_modules/rc-tree-select": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-5.4.1.tgz",
-      "integrity": "sha512-xhXnKP8Stu2Q7wTcjJaSzSOLd4wmFtUZOwmy1cioaWyPbpiKlYdnALXA/9U49HOaV3KFXdRHE9Yi0KYED7yOAQ==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-5.27.0.tgz",
+      "integrity": "sha512-2qTBTzwIT7LRI1o7zLyrCzmo5tQanmyGbSaGTIf7sYimCklAToVVfpMC6OAldSKolcnjorBYPNSKQqJmN3TCww==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.10.1",
+        "@babel/runtime": "^7.25.7",
         "classnames": "2.x",
-        "rc-select": "~14.1.0",
-        "rc-tree": "~5.6.1",
-        "rc-util": "^5.16.1"
+        "rc-select": "~14.16.2",
+        "rc-tree": "~5.13.0",
+        "rc-util": "^5.43.0"
       },
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
       }
     },
-    "node_modules/rc-trigger": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-5.3.4.tgz",
-      "integrity": "sha512-mQv+vas0TwKcjAO2izNPkqR4j86OemLRmvL2nOzdP9OWNWA1ivoTt5hzFqYNW9zACwmTezRiN8bttrC7cZzYSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "classnames": "^2.2.6",
-        "rc-align": "^4.0.0",
-        "rc-motion": "^2.0.0",
-        "rc-util": "^5.19.2"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
     "node_modules/rc-upload": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/rc-upload/-/rc-upload-4.3.6.tgz",
-      "integrity": "sha512-Bt7ESeG5tT3IY82fZcP+s0tQU2xmo1W6P3S8NboUUliquJLQYLkUcsaExi3IlBVr43GQMCjo30RA2o0i70+NjA==",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/rc-upload/-/rc-upload-4.9.2.tgz",
+      "integrity": "sha512-nHx+9rbd1FKMiMRYsqQ3NkXUv7COHPBo3X1Obwq9SWS6/diF/A0aJ5OHubvwUAIDs+4RMleljV0pcrNUc823GQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
@@ -6601,7 +6828,8 @@
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.1",
@@ -6757,11 +6985,12 @@
       }
     },
     "node_modules/scroll-into-view-if-needed": {
-      "version": "2.2.29",
-      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.29.tgz",
-      "integrity": "sha512-hxpAR6AN+Gh53AdAimHM6C8oTN1ppwVZITihix+WqalywBeFcQ6LdQP5ABNl26nX8GTEL7VT+b8lKpdqq65wXg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
+      "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
+      "license": "MIT",
       "dependencies": {
-        "compute-scroll-into-view": "^1.0.17"
+        "compute-scroll-into-view": "^3.0.2"
       }
     },
     "node_modules/semver": {
@@ -6773,11 +7002,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -6871,7 +7095,8 @@
     "node_modules/string-convert": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
-      "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A=="
+      "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==",
+      "license": "MIT"
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -6953,6 +7178,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -7045,6 +7276,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/throttle-debounce": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.2.tgz",
+      "integrity": "sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.22"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -7115,7 +7355,8 @@
     "node_modules/toggle-selection": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
-      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
@@ -7519,24 +7760,51 @@
       }
     },
     "@ant-design/colors": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-6.0.0.tgz",
-      "integrity": "sha512-qAZRvPzfdWHtfameEGP2Qvuf838NhergR35o+EuVyB5XvSA98xod5r4utvi4TJ3ywmevm290g9nsCG5MryrdWQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-8.0.0.tgz",
+      "integrity": "sha512-6YzkKCw30EI/E9kHOIXsQDHmMvTllT8STzjMb4K2qzit33RW2pqCJP0sk+hidBntXxE+Vz4n1+RvCTfBw6OErw==",
       "requires": {
-        "@ctrl/tinycolor": "^3.4.0"
+        "@ant-design/fast-color": "^3.0.0"
       }
     },
-    "@ant-design/icons": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-4.8.3.tgz",
-      "integrity": "sha512-HGlIQZzrEbAhpJR6+IGdzfbPym94Owr6JZkJ2QCCnOkPVIWMO2xgIVcOKnl8YcpijIo39V7l2qQL5fmtw56cMw==",
+    "@ant-design/cssinjs": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-1.24.0.tgz",
+      "integrity": "sha512-K4cYrJBsgvL+IoozUXYjbT6LHHNt+19a9zkvpBPxLjFHas1UpPM2A5MlhROb0BT8N8WoavM5VsP9MeSeNK/3mg==",
       "requires": {
-        "@ant-design/colors": "^6.0.0",
-        "@ant-design/icons-svg": "^4.3.0",
-        "@babel/runtime": "^7.11.2",
-        "classnames": "^2.2.6",
-        "lodash": "^4.17.15",
-        "rc-util": "^5.9.4"
+        "@babel/runtime": "^7.11.1",
+        "@emotion/hash": "^0.8.0",
+        "@emotion/unitless": "^0.7.5",
+        "classnames": "^2.3.1",
+        "csstype": "^3.1.3",
+        "rc-util": "^5.35.0",
+        "stylis": "^4.3.4"
+      }
+    },
+    "@ant-design/cssinjs-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs-utils/-/cssinjs-utils-1.1.3.tgz",
+      "integrity": "sha512-nOoQMLW1l+xR1Co8NFVYiP8pZp3VjIIzqV6D6ShYF2ljtdwWJn5WSsH+7kvCktXL/yhEtWURKOfH5Xz/gzlwsg==",
+      "requires": {
+        "@ant-design/cssinjs": "^1.21.0",
+        "@babel/runtime": "^7.23.2",
+        "rc-util": "^5.38.0"
+      }
+    },
+    "@ant-design/fast-color": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/fast-color/-/fast-color-3.0.0.tgz",
+      "integrity": "sha512-eqvpP7xEDm2S7dUzl5srEQCBTXZMmY3ekf97zI+M2DHOYyKdJGH0qua0JACHTqbkRnD/KHFQP9J1uMJ/XWVzzA=="
+    },
+    "@ant-design/icons": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-6.0.1.tgz",
+      "integrity": "sha512-BsAoYa8NTwh5GfpziqStAyWHNyp8vkc9PkuIR/Cu8O8WkhRzrpx260zd5ygsXMhQEGtfGGFjdAG0DfjhGBOBHw==",
+      "requires": {
+        "@ant-design/colors": "^8.0.0",
+        "@ant-design/icons-svg": "^4.4.0",
+        "@rc-component/util": "^1.2.1",
+        "classnames": "^2.2.6"
       }
     },
     "@ant-design/icons-svg": {
@@ -7545,15 +7813,15 @@
       "integrity": "sha512-vHbT+zJEVzllwP+CM+ul7reTEfBR0vgxFe7+lREAsAA7YGsYpboiq2sQNeQeRvh09GfQgs/GyFEvZpJ9cLXpXA=="
     },
     "@ant-design/react-slick": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-0.29.2.tgz",
-      "integrity": "sha512-kgjtKmkGHa19FW21lHnAfyyH9AAoh35pBdcJ53rHmQ3O+cfFHGHnUbj/HFrRNJ5vIts09FKJVAD8RpaC+RaWfA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-1.1.2.tgz",
+      "integrity": "sha512-EzlvzE6xQUBrZuuhSAFTdsr4P2bBBHGZwKFemEfq8gIGyIQCxalYfZW/T2ORbtQx5rU69o+WycP3exY/7T1hGA==",
       "requires": {
         "@babel/runtime": "^7.10.4",
         "classnames": "^2.2.5",
         "json2mq": "^0.2.0",
-        "lodash": "^4.17.21",
-        "resize-observer-polyfill": "^1.5.1"
+        "resize-observer-polyfill": "^1.5.1",
+        "throttle-debounce": "^5.0.0"
       }
     },
     "@apollo/client": {
@@ -7913,10 +8181,15 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "@ctrl/tinycolor": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.4.1.tgz",
-      "integrity": "sha512-ej5oVy6lykXsvieQtqZxCOaLT+xD4+QNarq78cIYISHmZXshCvROLudpQN3lfL8G0NL7plMSSK+zlyvCaIJ4Iw=="
+    "@emotion/hash": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+    },
+    "@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
     },
     "@esbuild/aix-ppc64": {
       "version": "0.25.9",
@@ -8578,6 +8851,123 @@
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
       "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
       "dev": true
+    },
+    "@rc-component/async-validator": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@rc-component/async-validator/-/async-validator-5.0.4.tgz",
+      "integrity": "sha512-qgGdcVIF604M9EqjNF0hbUTz42bz/RDtxWdWuU5EQe3hi7M8ob54B6B35rOsvX5eSvIHIzT9iH1R3n+hk3CGfg==",
+      "requires": {
+        "@babel/runtime": "^7.24.4"
+      }
+    },
+    "@rc-component/color-picker": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/color-picker/-/color-picker-2.0.1.tgz",
+      "integrity": "sha512-WcZYwAThV/b2GISQ8F+7650r5ZZJ043E57aVBFkQ+kSY4C6wdofXgB0hBx+GPGpIU0Z81eETNoDUJMr7oy/P8Q==",
+      "requires": {
+        "@ant-design/fast-color": "^2.0.6",
+        "@babel/runtime": "^7.23.6",
+        "classnames": "^2.2.6",
+        "rc-util": "^5.38.1"
+      },
+      "dependencies": {
+        "@ant-design/fast-color": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@ant-design/fast-color/-/fast-color-2.0.6.tgz",
+          "integrity": "sha512-y2217gk4NqL35giHl72o6Zzqji9O7vHh9YmhUVkPtAOpoTCH4uWxo/pr4VE8t0+ChEPs0qo4eJRC5Q1eXWo3vA==",
+          "requires": {
+            "@babel/runtime": "^7.24.7"
+          }
+        }
+      }
+    },
+    "@rc-component/context": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/context/-/context-1.4.0.tgz",
+      "integrity": "sha512-kFcNxg9oLRMoL3qki0OMxK+7g5mypjgaaJp/pkOis/6rVxma9nJBF/8kCIuTYHUQNr0ii7MxqE33wirPZLJQ2w==",
+      "requires": {
+        "@babel/runtime": "^7.10.1",
+        "rc-util": "^5.27.0"
+      }
+    },
+    "@rc-component/mini-decimal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/mini-decimal/-/mini-decimal-1.1.0.tgz",
+      "integrity": "sha512-jS4E7T9Li2GuYwI6PyiVXmxTiM6b07rlD9Ge8uGZSCz3WlzcG5ZK7g5bbuKNeZ9pgUuPK/5guV781ujdVpm4HQ==",
+      "requires": {
+        "@babel/runtime": "^7.18.0"
+      }
+    },
+    "@rc-component/mutate-observer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/mutate-observer/-/mutate-observer-1.1.0.tgz",
+      "integrity": "sha512-QjrOsDXQusNwGZPf4/qRQasg7UFEj06XiCJ8iuiq/Io7CrHrgVi6Uuetw60WAMG1799v+aM8kyc+1L/GBbHSlw==",
+      "requires": {
+        "@babel/runtime": "^7.18.0",
+        "classnames": "^2.3.2",
+        "rc-util": "^5.24.4"
+      }
+    },
+    "@rc-component/portal": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-1.1.2.tgz",
+      "integrity": "sha512-6f813C0IsasTZms08kfA8kPAGxbbkYToa8ALaiDIGGECU4i9hj8Plgbx0sNJDrey3EtHO30hmdaxtT0138xZcg==",
+      "requires": {
+        "@babel/runtime": "^7.18.0",
+        "classnames": "^2.3.2",
+        "rc-util": "^5.24.4"
+      }
+    },
+    "@rc-component/qrcode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/qrcode/-/qrcode-1.0.0.tgz",
+      "integrity": "sha512-L+rZ4HXP2sJ1gHMGHjsg9jlYBX/SLN2D6OxP9Zn3qgtpMWtO2vUfxVFwiogHpAIqs54FnALxraUy/BCO1yRIgg==",
+      "requires": {
+        "@babel/runtime": "^7.24.7",
+        "classnames": "^2.3.2",
+        "rc-util": "^5.38.0"
+      }
+    },
+    "@rc-component/tour": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/tour/-/tour-1.15.1.tgz",
+      "integrity": "sha512-Tr2t7J1DKZUpfJuDZWHxyxWpfmj8EZrqSgyMZ+BCdvKZ6r1UDsfU46M/iWAAFBy961Ssfom2kv5f3UcjIL2CmQ==",
+      "requires": {
+        "@babel/runtime": "^7.18.0",
+        "@rc-component/portal": "^1.0.0-9",
+        "@rc-component/trigger": "^2.0.0",
+        "classnames": "^2.3.2",
+        "rc-util": "^5.24.4"
+      }
+    },
+    "@rc-component/trigger": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-2.3.0.tgz",
+      "integrity": "sha512-iwaxZyzOuK0D7lS+0AQEtW52zUWxoGqTGkke3dRyb8pYiShmRpCjB/8TzPI4R6YySCH7Vm9BZj/31VPiiQTLBg==",
+      "requires": {
+        "@babel/runtime": "^7.23.2",
+        "@rc-component/portal": "^1.1.0",
+        "classnames": "^2.3.2",
+        "rc-motion": "^2.0.0",
+        "rc-resize-observer": "^1.3.1",
+        "rc-util": "^5.44.0"
+      }
+    },
+    "@rc-component/util": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/util/-/util-1.3.0.tgz",
+      "integrity": "sha512-hfXE04CVsxI/slmWKeSh6du7sSKpbvVdVEZCa8A+2QWDlL97EsCYme2c3ZWLn1uC9FR21JoewlrhUPWO4QgO8w==",
+      "requires": {
+        "is-mobile": "^5.0.0",
+        "react-is": "^18.2.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.3.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+          "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+        }
+      }
     },
     "@rolldown/pluginutils": {
       "version": "1.0.0-beta.34",
@@ -9254,54 +9644,89 @@
       }
     },
     "antd": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/antd/-/antd-4.22.4.tgz",
-      "integrity": "sha512-u7l68PhSJMxyZmCNw+jwaeurSAaE+bU+lB0SPRHLfOFJR6xRudntvRoQdiEFOD5FZ3eeqz4lYQ3RZZRIarmceg==",
+      "version": "5.27.3",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-5.27.3.tgz",
+      "integrity": "sha512-Jewp1ek1iyqoAyjWyPgzc2kioZ+7S3jh39a+tld/j4ucnuf/cBk4omfyIdhLz49pVNsaEcRp5LtJOSQPFwPgpA==",
       "requires": {
-        "@ant-design/colors": "^6.0.0",
-        "@ant-design/icons": "^4.7.0",
-        "@ant-design/react-slick": "~0.29.1",
-        "@babel/runtime": "^7.18.3",
-        "@ctrl/tinycolor": "^3.4.0",
-        "classnames": "^2.2.6",
-        "copy-to-clipboard": "^3.2.0",
-        "lodash": "^4.17.21",
-        "memoize-one": "^6.0.0",
-        "moment": "^2.29.2",
-        "rc-cascader": "~3.6.0",
-        "rc-checkbox": "~2.3.0",
-        "rc-collapse": "~3.3.0",
-        "rc-dialog": "~8.9.0",
-        "rc-drawer": "~5.1.0-alpha.1",
-        "rc-dropdown": "~4.0.0",
-        "rc-field-form": "~1.27.0",
-        "rc-image": "~5.7.0",
-        "rc-input": "~0.0.1-alpha.5",
-        "rc-input-number": "~7.3.5",
-        "rc-mentions": "~1.9.1",
-        "rc-menu": "~9.6.0",
-        "rc-motion": "^2.6.1",
-        "rc-notification": "~4.6.0",
-        "rc-pagination": "~3.1.17",
-        "rc-picker": "~2.6.10",
-        "rc-progress": "~3.3.2",
-        "rc-rate": "~2.9.0",
-        "rc-resize-observer": "^1.2.0",
-        "rc-segmented": "~2.1.0",
-        "rc-select": "~14.1.1",
-        "rc-slider": "~10.0.0",
-        "rc-steps": "~4.1.0",
-        "rc-switch": "~3.2.0",
-        "rc-table": "~7.25.3",
-        "rc-tabs": "~11.16.0",
-        "rc-textarea": "~0.3.0",
-        "rc-tooltip": "~5.2.0",
-        "rc-tree": "~5.6.5",
-        "rc-tree-select": "~5.4.0",
-        "rc-trigger": "^5.2.10",
-        "rc-upload": "~4.3.0",
-        "rc-util": "^5.22.5",
-        "scroll-into-view-if-needed": "^2.2.25"
+        "@ant-design/colors": "^7.2.1",
+        "@ant-design/cssinjs": "^1.23.0",
+        "@ant-design/cssinjs-utils": "^1.1.3",
+        "@ant-design/fast-color": "^2.0.6",
+        "@ant-design/icons": "^5.6.1",
+        "@ant-design/react-slick": "~1.1.2",
+        "@babel/runtime": "^7.26.0",
+        "@rc-component/color-picker": "~2.0.1",
+        "@rc-component/mutate-observer": "^1.1.0",
+        "@rc-component/qrcode": "~1.0.0",
+        "@rc-component/tour": "~1.15.1",
+        "@rc-component/trigger": "^2.3.0",
+        "classnames": "^2.5.1",
+        "copy-to-clipboard": "^3.3.3",
+        "dayjs": "^1.11.11",
+        "rc-cascader": "~3.34.0",
+        "rc-checkbox": "~3.5.0",
+        "rc-collapse": "~3.9.0",
+        "rc-dialog": "~9.6.0",
+        "rc-drawer": "~7.3.0",
+        "rc-dropdown": "~4.2.1",
+        "rc-field-form": "~2.7.0",
+        "rc-image": "~7.12.0",
+        "rc-input": "~1.8.0",
+        "rc-input-number": "~9.5.0",
+        "rc-mentions": "~2.20.0",
+        "rc-menu": "~9.16.1",
+        "rc-motion": "^2.9.5",
+        "rc-notification": "~5.6.4",
+        "rc-pagination": "~5.1.0",
+        "rc-picker": "~4.11.3",
+        "rc-progress": "~4.0.0",
+        "rc-rate": "~2.13.1",
+        "rc-resize-observer": "^1.4.3",
+        "rc-segmented": "~2.7.0",
+        "rc-select": "~14.16.8",
+        "rc-slider": "~11.1.8",
+        "rc-steps": "~6.0.1",
+        "rc-switch": "~4.1.0",
+        "rc-table": "~7.52.6",
+        "rc-tabs": "~15.7.0",
+        "rc-textarea": "~1.10.2",
+        "rc-tooltip": "~6.4.0",
+        "rc-tree": "~5.13.1",
+        "rc-tree-select": "~5.27.0",
+        "rc-upload": "~4.9.2",
+        "rc-util": "^5.44.4",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "throttle-debounce": "^5.0.2"
+      },
+      "dependencies": {
+        "@ant-design/colors": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-7.2.1.tgz",
+          "integrity": "sha512-lCHDcEzieu4GA3n8ELeZ5VQ8pKQAWcGGLRTQ50aQM2iqPpq2evTxER84jfdPvsPAtEcZ7m44NI45edFMo8oOYQ==",
+          "requires": {
+            "@ant-design/fast-color": "^2.0.6"
+          }
+        },
+        "@ant-design/fast-color": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@ant-design/fast-color/-/fast-color-2.0.6.tgz",
+          "integrity": "sha512-y2217gk4NqL35giHl72o6Zzqji9O7vHh9YmhUVkPtAOpoTCH4uWxo/pr4VE8t0+ChEPs0qo4eJRC5Q1eXWo3vA==",
+          "requires": {
+            "@babel/runtime": "^7.24.7"
+          }
+        },
+        "@ant-design/icons": {
+          "version": "5.6.1",
+          "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.6.1.tgz",
+          "integrity": "sha512-0/xS39c91WjPAZOWsvi1//zjx6kAp4kxWwctR6kuU6p133w8RU0D2dSCvZC19uQyharg/sAvYxGYWl01BbZZfg==",
+          "requires": {
+            "@ant-design/colors": "^7.0.0",
+            "@ant-design/icons-svg": "^4.4.0",
+            "@babel/runtime": "^7.24.8",
+            "classnames": "^2.2.6",
+            "rc-util": "^5.31.1"
+          }
+        }
       }
     },
     "anymatch": {
@@ -9328,16 +9753,6 @@
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
       "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
       "dev": true
-    },
-    "array-tree-filter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-tree-filter/-/array-tree-filter-2.1.0.tgz",
-      "integrity": "sha512-4ROwICNlNw/Hqa9v+rk5h22KjmzB1JGTMVKP2AKJBOCgb0yL0ASf0+YvCcLNNwquOHNX48jkeZIJ3a+oOQqKcw=="
-    },
-    "async-validator": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/async-validator/-/async-validator-4.2.5.tgz",
-      "integrity": "sha512-7HhHjtERjqlNbZtqNqy2rckN/SpOOlmDliet+lP7k+eKZEjPk3DgyeU9lIXLdeLz0uBbbVp+9Qdow9wJWgwwfg=="
     },
     "babel-jest": {
       "version": "28.1.3",
@@ -9508,9 +9923,9 @@
       "dev": true
     },
     "classnames": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "cliui": {
       "version": "7.0.4",
@@ -9551,9 +9966,9 @@
       "dev": true
     },
     "compute-scroll-into-view": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz",
-      "integrity": "sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -9571,9 +9986,9 @@
       }
     },
     "copy-to-clipboard": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.2.tgz",
-      "integrity": "sha512-Vme1Z6RUDzrb6xAI7EZlVZ5uvOk2F//GaxKUxajDqm9LhOVM1inxNAD2vy+UZDYsd0uyA9s7b3/FVZPSxqrCfg==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
       "requires": {
         "toggle-selection": "^1.0.6"
       }
@@ -9596,18 +10011,9 @@
       "dev": true
     },
     "csstype": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
-      "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==",
-      "dev": true
-    },
-    "date-fns": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-      "requires": {
-        "@babel/runtime": "^7.21.0"
-      }
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "dayjs": {
       "version": "1.11.18",
@@ -9658,11 +10064,6 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz",
       "integrity": "sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==",
       "dev": true
-    },
-    "dom-align": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.12.4.tgz",
-      "integrity": "sha512-R8LUSEay/68zE5c8/3BDxiTEvgb4xZTF0RKmAHfiEVN3klfIpXfi2/QCoiWPccVQ0J/ZGdz9OjzL4uJEP/MRAw=="
     },
     "electron-to-chromium": {
       "version": "1.5.214",
@@ -10303,6 +10704,11 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
+    },
+    "is-mobile": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-5.0.0.tgz",
+      "integrity": "sha512-Tz/yndySvLAEXh+Uk8liFCxOwVH6YutuR74utvOcu7I9Di+DwM0mtdPVZNaVvvBUM2OXxne/NhOs1zAO7riusQ=="
     },
     "is-number": {
       "version": "7.0.0",
@@ -11145,7 +11551,8 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.merge": {
       "version": "4.6.2",
@@ -11194,11 +11601,6 @@
         "tmpl": "1.0.5"
       }
     },
-    "memoize-one": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
-      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
-    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -11241,11 +11643,6 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
-    },
-    "moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "ms": {
       "version": "2.1.2",
@@ -11534,110 +11931,101 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
-    "rc-align": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.15.tgz",
-      "integrity": "sha512-wqJtVH60pka/nOX7/IspElA8gjPNQKIx/ZqJ6heATCkXpe1Zg4cPVrMD2vC96wjsFFL8WsmhPbx9tdMo1qqlIA==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "dom-align": "^1.7.0",
-        "rc-util": "^5.26.0",
-        "resize-observer-polyfill": "^1.5.1"
-      }
-    },
     "rc-cascader": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-3.6.2.tgz",
-      "integrity": "sha512-sf2otpazlROTzkD3nZVfIzXmfBLiEOBTXA5wxozGXBpS902McDpvF0bdcYBu5hN+rviEAm6Mh9cLXNQ1Ty8wKQ==",
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-3.34.0.tgz",
+      "integrity": "sha512-KpXypcvju9ptjW9FaN2NFcA2QH9E9LHKq169Y0eWtH4e/wHQ5Wh5qZakAgvb8EKZ736WZ3B0zLLOBsrsja5Dag==",
       "requires": {
-        "@babel/runtime": "^7.12.5",
-        "array-tree-filter": "^2.1.0",
+        "@babel/runtime": "^7.25.7",
         "classnames": "^2.3.1",
-        "rc-select": "~14.1.0",
-        "rc-tree": "~5.6.3",
-        "rc-util": "^5.6.1"
+        "rc-select": "~14.16.2",
+        "rc-tree": "~5.13.0",
+        "rc-util": "^5.43.0"
       }
     },
     "rc-checkbox": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/rc-checkbox/-/rc-checkbox-2.3.2.tgz",
-      "integrity": "sha512-afVi1FYiGv1U0JlpNH/UaEXdh6WUJjcWokj/nUN2TgG80bfG+MDdbfHKlLcNNba94mbjy2/SXJ1HDgrOkXGAjg==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/rc-checkbox/-/rc-checkbox-3.5.0.tgz",
+      "integrity": "sha512-aOAQc3E98HteIIsSqm6Xk2FPKIER6+5vyEFMZfo73TqM+VVAIqOkHoPjgKLqSNtVLWScoaM7vY2ZrGEheI79yg==",
       "requires": {
         "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.1"
+        "classnames": "^2.3.2",
+        "rc-util": "^5.25.2"
       }
     },
     "rc-collapse": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-3.3.1.tgz",
-      "integrity": "sha512-cOJfcSe3R8vocrF8T+PgaHDrgeA1tX+lwfhwSj60NX9QVRidsILIbRNDLD6nAzmcvVC5PWiIRiR4S1OobxdhCg==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-3.9.0.tgz",
+      "integrity": "sha512-swDdz4QZ4dFTo4RAUMLL50qP0EY62N2kvmk2We5xYdRwcRn8WcYtuetCJpwpaCbUfUt5+huLpVxhvmnK+PHrkA==",
       "requires": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
         "rc-motion": "^2.3.4",
-        "rc-util": "^5.2.1",
-        "shallowequal": "^1.1.0"
+        "rc-util": "^5.27.0"
       }
     },
     "rc-dialog": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-8.9.0.tgz",
-      "integrity": "sha512-Cp0tbJnrvPchJfnwIvOMWmJ4yjX3HWFatO6oBFD1jx8QkgsQCR0p8nUWAKdd3seLJhEC39/v56kZaEjwp9muoQ==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-9.6.0.tgz",
+      "integrity": "sha512-ApoVi9Z8PaCQg6FsUzS8yvBEQy0ZL2PkuvAgrmohPkN3okps5WZ5WQWPc1RNuiOKaAYv8B97ACdsFU5LizzCqg==",
       "requires": {
         "@babel/runtime": "^7.10.1",
+        "@rc-component/portal": "^1.0.0-8",
         "classnames": "^2.2.6",
         "rc-motion": "^2.3.0",
         "rc-util": "^5.21.0"
       }
     },
     "rc-drawer": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/rc-drawer/-/rc-drawer-5.1.0.tgz",
-      "integrity": "sha512-pU3Tsn99pxGdYowXehzZbdDVE+4lDXSGb7p8vA9mSmr569oc2Izh4Zw5vLKSe/Xxn2p5MSNbLVqD4tz+pK6SOw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/rc-drawer/-/rc-drawer-7.3.0.tgz",
+      "integrity": "sha512-DX6CIgiBWNpJIMGFO8BAISFkxiuKitoizooj4BDyee8/SnBn0zwO2FHrNDpqqepj0E/TFTDpmEBCyFuTgC7MOg==",
       "requires": {
-        "@babel/runtime": "^7.10.1",
+        "@babel/runtime": "^7.23.9",
+        "@rc-component/portal": "^1.1.1",
         "classnames": "^2.2.6",
         "rc-motion": "^2.6.1",
-        "rc-util": "^5.21.2"
+        "rc-util": "^5.38.1"
       }
     },
     "rc-dropdown": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-4.0.1.tgz",
-      "integrity": "sha512-OdpXuOcme1rm45cR0Jzgfl1otzmU4vuBVb+etXM8vcaULGokAKVpKlw8p6xzspG7jGd/XxShvq+N3VNEfk/l5g==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-4.2.1.tgz",
+      "integrity": "sha512-YDAlXsPv3I1n42dv1JpdM7wJ+gSUBfeyPK59ZpBD9jQhK9jVuxpjj3NmWQHOBceA1zEPVX84T2wbdb2SD0UjmA==",
       "requires": {
         "@babel/runtime": "^7.18.3",
+        "@rc-component/trigger": "^2.0.0",
         "classnames": "^2.2.6",
-        "rc-trigger": "^5.3.1",
-        "rc-util": "^5.17.0"
+        "rc-util": "^5.44.1"
       }
     },
     "rc-field-form": {
-      "version": "1.27.4",
-      "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-1.27.4.tgz",
-      "integrity": "sha512-PQColQnZimGKArnOh8V2907+VzDCXcqtFvHgevDLtqWc/P7YASb/FqntSmdS8q3VND5SHX3Y1vgMIzY22/f/0Q==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-2.7.0.tgz",
+      "integrity": "sha512-hgKsCay2taxzVnBPZl+1n4ZondsV78G++XVsMIJCAoioMjlMQR9YwAp7JZDIECzIu2Z66R+f4SFIRrO2DjDNAA==",
       "requires": {
         "@babel/runtime": "^7.18.0",
-        "async-validator": "^4.1.0",
-        "rc-util": "^5.8.0"
+        "@rc-component/async-validator": "^5.0.3",
+        "rc-util": "^5.32.2"
       }
     },
     "rc-image": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/rc-image/-/rc-image-5.7.1.tgz",
-      "integrity": "sha512-QyMfdhoUfb5W14plqXSisaYwpdstcLYnB0MjX5ccIK2rydQM9sDPuekQWu500DDGR2dBaIF5vx9XbWkNFK17Fg==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/rc-image/-/rc-image-7.12.0.tgz",
+      "integrity": "sha512-cZ3HTyyckPnNnUb9/DRqduqzLfrQRyi+CdHjdqgsyDpI3Ln5UX1kXnAhPBSJj9pVRzwRFgqkN7p9b6HBDjmu/Q==",
       "requires": {
         "@babel/runtime": "^7.11.2",
+        "@rc-component/portal": "^1.0.2",
         "classnames": "^2.2.6",
-        "rc-dialog": "~8.9.0",
-        "rc-util": "^5.0.6"
+        "rc-dialog": "~9.6.0",
+        "rc-motion": "^2.6.2",
+        "rc-util": "^5.34.1"
       }
     },
     "rc-input": {
-      "version": "0.0.1-alpha.7",
-      "resolved": "https://registry.npmjs.org/rc-input/-/rc-input-0.0.1-alpha.7.tgz",
-      "integrity": "sha512-eozaqpCYWSY5LBMwlHgC01GArkVEP+XlJ84OMvdkwUnJBSv83Yxa15pZpn7vACAj84uDC4xOA2CoFdbLuqB08Q==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/rc-input/-/rc-input-1.8.0.tgz",
+      "integrity": "sha512-KXvaTbX+7ha8a/k+eg6SYRVERK0NddX8QX7a7AnRvUa/rEH0CNMlpcBzBkhI0wp2C8C4HlMoYl8TImSN+fuHKA==",
       "requires": {
         "@babel/runtime": "^7.11.1",
         "classnames": "^2.2.1",
@@ -11645,40 +12033,42 @@
       }
     },
     "rc-input-number": {
-      "version": "7.3.11",
-      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-7.3.11.tgz",
-      "integrity": "sha512-aMWPEjFeles6PQnMqP5eWpxzsvHm9rh1jQOWXExUEIxhX62Fyl/ptifLHOn17+waDG1T/YUb6flfJbvwRhHrbA==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-9.5.0.tgz",
+      "integrity": "sha512-bKaEvB5tHebUURAEXw35LDcnRZLq3x1k7GxfAqBMzmpHkDGzjAtnUL8y4y5N15rIFIg5IJgwr211jInl3cipag==",
       "requires": {
         "@babel/runtime": "^7.10.1",
+        "@rc-component/mini-decimal": "^1.0.1",
         "classnames": "^2.2.5",
-        "rc-util": "^5.23.0"
+        "rc-input": "~1.8.0",
+        "rc-util": "^5.40.1"
       }
     },
     "rc-mentions": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-1.9.2.tgz",
-      "integrity": "sha512-uxb/lzNnEGmvraKWNGE6KXMVXvt8RQv9XW8R0Dqi3hYsyPiAZeHRCHQKdLARuk5YBhFhZ6ga55D/8XuY367g3g==",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-2.20.0.tgz",
+      "integrity": "sha512-w8HCMZEh3f0nR8ZEd466ATqmXFCMGMN5UFCzEUL0bM/nGw/wOS2GgRzKBcm19K++jDyuWCOJOdgcKGXU3fXfbQ==",
       "requires": {
-        "@babel/runtime": "^7.10.1",
+        "@babel/runtime": "^7.22.5",
+        "@rc-component/trigger": "^2.0.0",
         "classnames": "^2.2.6",
-        "rc-menu": "~9.6.0",
-        "rc-textarea": "^0.3.0",
-        "rc-trigger": "^5.0.4",
-        "rc-util": "^5.22.5"
+        "rc-input": "~1.8.0",
+        "rc-menu": "~9.16.0",
+        "rc-textarea": "~1.10.0",
+        "rc-util": "^5.34.1"
       }
     },
     "rc-menu": {
-      "version": "9.6.4",
-      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.6.4.tgz",
-      "integrity": "sha512-6DiNAjxjVIPLZXHffXxxcyE15d4isRL7iQ1ru4MqYDH2Cqc5bW96wZOdMydFtGLyDdnmEQ9jVvdCE9yliGvzkw==",
+      "version": "9.16.1",
+      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.16.1.tgz",
+      "integrity": "sha512-ghHx6/6Dvp+fw8CJhDUHFHDJ84hJE3BXNCzSgLdmNiFErWSOaZNsihDAsKq9ByTALo/xkNIwtDFGIl6r+RPXBg==",
       "requires": {
         "@babel/runtime": "^7.10.1",
+        "@rc-component/trigger": "^2.0.0",
         "classnames": "2.x",
         "rc-motion": "^2.4.3",
-        "rc-overflow": "^1.2.0",
-        "rc-trigger": "^5.1.2",
-        "rc-util": "^5.12.0",
-        "shallowequal": "^1.1.0"
+        "rc-overflow": "^1.3.1",
+        "rc-util": "^5.27.0"
       }
     },
     "rc-motion": {
@@ -11692,13 +12082,13 @@
       }
     },
     "rc-notification": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-4.6.1.tgz",
-      "integrity": "sha512-NSmFYwrrdY3+un1GvDAJQw62Xi9LNMSsoQyo95tuaYrcad5Bn9gJUL8AREufRxSQAQnr64u3LtP3EUyLYT6bhw==",
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-5.6.4.tgz",
+      "integrity": "sha512-KcS4O6B4qzM3KH7lkwOB7ooLPZ4b6J+VMmQgT51VZCeEcmghdeR4IrMcFq0LG+RPdnbe/ArT086tGM8Snimgiw==",
       "requires": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
-        "rc-motion": "^2.2.0",
+        "rc-motion": "^2.9.0",
         "rc-util": "^5.20.1"
       }
     },
@@ -11714,33 +12104,32 @@
       }
     },
     "rc-pagination": {
-      "version": "3.1.17",
-      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-3.1.17.tgz",
-      "integrity": "sha512-/BQ5UxcBnW28vFAcP2hfh+Xg15W0QZn8TWYwdCApchMH1H0CxiaUUcULP8uXcFM1TygcdKWdt3JqsL9cTAfdkQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-5.1.0.tgz",
+      "integrity": "sha512-8416Yip/+eclTFdHXLKTxZvn70duYVGTvUUWbckCCZoIl3jagqke3GLsFrMs0bsQBikiYpZLD9206Ej4SOdOXQ==",
       "requires": {
         "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.1"
+        "classnames": "^2.3.2",
+        "rc-util": "^5.38.0"
       }
     },
     "rc-picker": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-2.6.11.tgz",
-      "integrity": "sha512-INJ7ULu+Kj4UgqbcqE8Q+QpMw55xFf9kkyLBHJFk0ihjJpAV4glialRfqHE7k4KX2BWYPQfpILwhwR14x2EiRQ==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-4.11.3.tgz",
+      "integrity": "sha512-MJ5teb7FlNE0NFHTncxXQ62Y5lytq6sh5nUw0iH8OkHL/TjARSEvSHpr940pWgjGANpjCwyMdvsEV55l5tYNSg==",
       "requires": {
-        "@babel/runtime": "^7.10.1",
+        "@babel/runtime": "^7.24.7",
+        "@rc-component/trigger": "^2.0.0",
         "classnames": "^2.2.1",
-        "date-fns": "2.x",
-        "dayjs": "1.x",
-        "moment": "^2.24.0",
-        "rc-trigger": "^5.0.4",
-        "rc-util": "^5.4.0",
-        "shallowequal": "^1.1.0"
+        "rc-overflow": "^1.3.2",
+        "rc-resize-observer": "^1.4.0",
+        "rc-util": "^5.43.0"
       }
     },
     "rc-progress": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/rc-progress/-/rc-progress-3.3.3.tgz",
-      "integrity": "sha512-MDVNVHzGanYtRy2KKraEaWeZLri2ZHWIRyaE1a9MQ2MuJ09m+Wxj5cfcaoaR6z5iRpHpA59YeUxAlpML8N4PJw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rc-progress/-/rc-progress-4.0.0.tgz",
+      "integrity": "sha512-oofVMMafOCokIUIBnZLNcOZFsABaUw8PPrf1/y0ZBvKZNpOiu5h4AO9vv11Sw0p4Hb3D0yGWuEattcQGtNJ/aw==",
       "requires": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.6",
@@ -11748,9 +12137,9 @@
       }
     },
     "rc-rate": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/rc-rate/-/rc-rate-2.9.3.tgz",
-      "integrity": "sha512-2THssUSnRhtqIouQIIXqsZGzRczvp4WsH4WvGuhiwm+LG2fVpDUJliP9O1zeDOZvYfBE/Bup4SgHun/eCkbjgQ==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/rc-rate/-/rc-rate-2.13.1.tgz",
+      "integrity": "sha512-QUhQ9ivQ8Gy7mtMZPAjLbxBt5y9GRp65VcUyGUMF3N3fhiftivPHdpuDIaWIMOTEprAjZPC08bls1dQB+I1F2Q==",
       "requires": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.5",
@@ -11769,9 +12158,9 @@
       }
     },
     "rc-segmented": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/rc-segmented/-/rc-segmented-2.1.2.tgz",
-      "integrity": "sha512-qGo1bCr83ESXpXVOCXjFe1QJlCAQXyi9KCiy8eX3rIMYlTeJr/ftySIaTnYsitL18SvWf5ZEHsfqIWoX0EMfFQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/rc-segmented/-/rc-segmented-2.7.0.tgz",
+      "integrity": "sha512-liijAjXz+KnTRVnxxXG2sYDGd6iLL7VpGGdR8gwoxAXy2KglviKCxLWZdjKYJzYzGSUwKDSTdYk8brj54Bn5BA==",
       "requires": {
         "@babel/runtime": "^7.11.1",
         "classnames": "^2.2.1",
@@ -11780,137 +12169,127 @@
       }
     },
     "rc-select": {
-      "version": "14.1.18",
-      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-14.1.18.tgz",
-      "integrity": "sha512-4JgY3oG2Yz68ECMUSCON7mtxuJvCSj+LJpHEg/AONaaVBxIIrmI/ZTuMJkyojall/X50YdBe5oMKqHHPNiPzEg==",
+      "version": "14.16.8",
+      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-14.16.8.tgz",
+      "integrity": "sha512-NOV5BZa1wZrsdkKaiK7LHRuo5ZjZYMDxPP6/1+09+FB4KoNi8jcG1ZqLE3AVCxEsYMBe65OBx71wFoHRTP3LRg==",
       "requires": {
         "@babel/runtime": "^7.10.1",
+        "@rc-component/trigger": "^2.1.1",
         "classnames": "2.x",
         "rc-motion": "^2.0.1",
-        "rc-overflow": "^1.0.0",
-        "rc-trigger": "^5.0.4",
+        "rc-overflow": "^1.3.1",
         "rc-util": "^5.16.1",
-        "rc-virtual-list": "^3.2.0"
+        "rc-virtual-list": "^3.5.2"
       }
     },
     "rc-slider": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-10.0.1.tgz",
-      "integrity": "sha512-igTKF3zBet7oS/3yNiIlmU8KnZ45npmrmHlUUio8PNbIhzMcsh+oE/r2UD42Y6YD2D/s+kzCQkzQrPD6RY435Q==",
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-11.1.8.tgz",
+      "integrity": "sha512-2gg/72YFSpKP+Ja5AjC5DPL1YnV8DEITDQrcc1eASrUYjl0esptaBVJBh5nLTXCCp15eD8EuGjwezVGSHhs9tQ==",
       "requires": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.5",
-        "rc-util": "^5.18.1",
-        "shallowequal": "^1.1.0"
+        "rc-util": "^5.36.0"
       }
     },
     "rc-steps": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/rc-steps/-/rc-steps-4.1.4.tgz",
-      "integrity": "sha512-qoCqKZWSpkh/b03ASGx1WhpKnuZcRWmvuW+ZUu4mvMdfvFzVxblTwUM+9aBd0mlEUFmt6GW8FXhMpHkK3Uzp3w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rc-steps/-/rc-steps-6.0.1.tgz",
+      "integrity": "sha512-lKHL+Sny0SeHkQKKDJlAjV5oZ8DwCdS2hFhAkIjuQt1/pB81M0cA0ErVFdHq9+jmPmFw1vJB2F5NBzFXLJxV+g==",
       "requires": {
-        "@babel/runtime": "^7.10.2",
+        "@babel/runtime": "^7.16.7",
         "classnames": "^2.2.3",
-        "rc-util": "^5.0.1"
+        "rc-util": "^5.16.1"
       }
     },
     "rc-switch": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/rc-switch/-/rc-switch-3.2.2.tgz",
-      "integrity": "sha512-+gUJClsZZzvAHGy1vZfnwySxj+MjLlGRyXKXScrtCTcmiYNPzxDFOxdQ/3pK1Kt/0POvwJ/6ALOR8gwdXGhs+A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/rc-switch/-/rc-switch-4.1.0.tgz",
+      "integrity": "sha512-TI8ufP2Az9oEbvyCeVE4+90PDSljGyuwix3fV58p7HV2o4wBnVToEyomJRVyTaZeqNPAp+vqeo4Wnj5u0ZZQBg==",
       "requires": {
-        "@babel/runtime": "^7.10.1",
+        "@babel/runtime": "^7.21.0",
         "classnames": "^2.2.1",
-        "rc-util": "^5.0.1"
+        "rc-util": "^5.30.0"
       }
     },
     "rc-table": {
-      "version": "7.25.3",
-      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.25.3.tgz",
-      "integrity": "sha512-McsLJ2rg8EEpRBRYN4Pf9gT7ZNYnjvF9zrBpUBBbUX/fxk+eGi5ff1iPIhMyiHsH71/BmTUzX9nc9XqupD0nMg==",
+      "version": "7.52.6",
+      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.52.6.tgz",
+      "integrity": "sha512-FxcbhNEFhvg+2bV8KB2Z0RMZj5HFCtiUZU2XuAMwB6Fk3ry2RHtXQmKHpSekG8F480HoSpSmjQoq5/sjLUe6oA==",
       "requires": {
         "@babel/runtime": "^7.10.1",
+        "@rc-component/context": "^1.4.0",
         "classnames": "^2.2.5",
         "rc-resize-observer": "^1.1.0",
-        "rc-util": "^5.22.5",
-        "shallowequal": "^1.1.0"
+        "rc-util": "^5.44.3",
+        "rc-virtual-list": "^3.14.2"
       }
     },
     "rc-tabs": {
-      "version": "11.16.1",
-      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-11.16.1.tgz",
-      "integrity": "sha512-bR7Dap23YyfzZQwtKomhiFEFzZuE7WaKWo+ypNRSGB9PDKSc6tM12VP8LWYkvmmQHthgwP0WRN8nFbSJWuqLYw==",
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-15.7.0.tgz",
+      "integrity": "sha512-ZepiE+6fmozYdWf/9gVp7k56PKHB1YYoDsKeQA1CBlJ/POIhjkcYiv0AGP0w2Jhzftd3AVvZP/K+V+Lpi2ankA==",
       "requires": {
         "@babel/runtime": "^7.11.2",
         "classnames": "2.x",
-        "rc-dropdown": "~4.0.0",
-        "rc-menu": "~9.6.0",
+        "rc-dropdown": "~4.2.0",
+        "rc-menu": "~9.16.0",
+        "rc-motion": "^2.6.2",
         "rc-resize-observer": "^1.0.0",
-        "rc-util": "^5.5.0"
+        "rc-util": "^5.34.1"
       }
     },
     "rc-textarea": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/rc-textarea/-/rc-textarea-0.3.7.tgz",
-      "integrity": "sha512-yCdZ6binKmAQB13hc/oehh0E/QRwoPP1pjF21aHBxlgXO3RzPF6dUu4LG2R4FZ1zx/fQd2L1faktulrXOM/2rw==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/rc-textarea/-/rc-textarea-1.10.2.tgz",
+      "integrity": "sha512-HfaeXiaSlpiSp0I/pvWpecFEHpVysZ9tpDLNkxQbMvMz6gsr7aVZ7FpWP9kt4t7DB+jJXesYS0us1uPZnlRnwQ==",
       "requires": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.1",
+        "rc-input": "~1.8.0",
         "rc-resize-observer": "^1.0.0",
-        "rc-util": "^5.7.0",
-        "shallowequal": "^1.1.0"
+        "rc-util": "^5.27.0"
       }
     },
     "rc-tooltip": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-5.2.2.tgz",
-      "integrity": "sha512-jtQzU/18S6EI3lhSGoDYhPqNpWajMtS5VV/ld1LwyfrDByQpYmw/LW6U7oFXXLukjfDHQ7Ju705A82PRNFWYhg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-6.4.0.tgz",
+      "integrity": "sha512-kqyivim5cp8I5RkHmpsp1Nn/Wk+1oeloMv9c7LXNgDxUpGm+RbXJGL+OPvDlcRnx9DBeOe4wyOIl4OKUERyH1g==",
       "requires": {
         "@babel/runtime": "^7.11.2",
+        "@rc-component/trigger": "^2.0.0",
         "classnames": "^2.3.1",
-        "rc-trigger": "^5.0.0"
+        "rc-util": "^5.44.3"
       }
     },
     "rc-tree": {
-      "version": "5.6.9",
-      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-5.6.9.tgz",
-      "integrity": "sha512-si8aGuWQ2/sh2Ibk+WdUdDeAxoviT/+kDY+NLtJ+RhqfySqPFqWM5uHTwgFRrWUvKCqEeE/PjCYuuhHrK7Y7+A==",
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-5.13.1.tgz",
+      "integrity": "sha512-FNhIefhftobCdUJshO7M8uZTA9F4OPGVXqGfZkkD/5soDeOhwO06T/aKTrg0WD8gRg/pyfq+ql3aMymLHCTC4A==",
       "requires": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
         "rc-motion": "^2.0.1",
         "rc-util": "^5.16.1",
-        "rc-virtual-list": "^3.4.8"
+        "rc-virtual-list": "^3.5.1"
       }
     },
     "rc-tree-select": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-5.4.1.tgz",
-      "integrity": "sha512-xhXnKP8Stu2Q7wTcjJaSzSOLd4wmFtUZOwmy1cioaWyPbpiKlYdnALXA/9U49HOaV3KFXdRHE9Yi0KYED7yOAQ==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-5.27.0.tgz",
+      "integrity": "sha512-2qTBTzwIT7LRI1o7zLyrCzmo5tQanmyGbSaGTIf7sYimCklAToVVfpMC6OAldSKolcnjorBYPNSKQqJmN3TCww==",
       "requires": {
-        "@babel/runtime": "^7.10.1",
+        "@babel/runtime": "^7.25.7",
         "classnames": "2.x",
-        "rc-select": "~14.1.0",
-        "rc-tree": "~5.6.1",
-        "rc-util": "^5.16.1"
-      }
-    },
-    "rc-trigger": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-5.3.4.tgz",
-      "integrity": "sha512-mQv+vas0TwKcjAO2izNPkqR4j86OemLRmvL2nOzdP9OWNWA1ivoTt5hzFqYNW9zACwmTezRiN8bttrC7cZzYSw==",
-      "requires": {
-        "@babel/runtime": "^7.18.3",
-        "classnames": "^2.2.6",
-        "rc-align": "^4.0.0",
-        "rc-motion": "^2.0.0",
-        "rc-util": "^5.19.2"
+        "rc-select": "~14.16.2",
+        "rc-tree": "~5.13.0",
+        "rc-util": "^5.43.0"
       }
     },
     "rc-upload": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/rc-upload/-/rc-upload-4.3.6.tgz",
-      "integrity": "sha512-Bt7ESeG5tT3IY82fZcP+s0tQU2xmo1W6P3S8NboUUliquJLQYLkUcsaExi3IlBVr43GQMCjo30RA2o0i70+NjA==",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/rc-upload/-/rc-upload-4.9.2.tgz",
+      "integrity": "sha512-nHx+9rbd1FKMiMRYsqQ3NkXUv7COHPBo3X1Obwq9SWS6/diF/A0aJ5OHubvwUAIDs+4RMleljV0pcrNUc823GQ==",
       "requires": {
         "@babel/runtime": "^7.18.3",
         "classnames": "^2.2.5",
@@ -12095,11 +12474,11 @@
       }
     },
     "scroll-into-view-if-needed": {
-      "version": "2.2.29",
-      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.29.tgz",
-      "integrity": "sha512-hxpAR6AN+Gh53AdAimHM6C8oTN1ppwVZITihix+WqalywBeFcQ6LdQP5ABNl26nX8GTEL7VT+b8lKpdqq65wXg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
+      "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
       "requires": {
-        "compute-scroll-into-view": "^1.0.17"
+        "compute-scroll-into-view": "^3.0.2"
       }
     },
     "semver": {
@@ -12107,11 +12486,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true
-    },
-    "shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -12245,6 +12619,11 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
+    "stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ=="
+    },
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -12304,6 +12683,11 @@
         "glob": "^7.1.4",
         "minimatch": "^3.0.4"
       }
+    },
+    "throttle-debounce": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.2.tgz",
+      "integrity": "sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A=="
     },
     "tinyglobby": {
       "version": "0.2.14",

--- a/chat-app-front/package.json
+++ b/chat-app-front/package.json
@@ -13,9 +13,9 @@
     "test": "jest"
   },
   "dependencies": {
-    "@ant-design/icons": "^4.7.0",
+    "@ant-design/icons": "^6.0.1",
     "@apollo/client": "^3.6.9",
-    "antd": "^4.21.7",
+    "antd": "^5.27.3",
     "graphql": "^16.5.0",
     "graphql-ws": "^5.9.1",
     "react": "^18.3.1",

--- a/chat-app-front/src/components/ChatLayout.tsx
+++ b/chat-app-front/src/components/ChatLayout.tsx
@@ -1,5 +1,5 @@
 import { SendOutlined, TeamOutlined, UserOutlined } from '@ant-design/icons';
-import { Button, Input, MenuProps, Radio } from 'antd';
+import { Button, Input, MenuProps, Radio, Space } from 'antd';
 import { Layout, Menu } from 'antd';
 import React, { useContext, useEffect, useState } from 'react';
 import { ThemeContext } from './themes/ThemeProvider';
@@ -128,7 +128,9 @@ const ChatLayout = () => {
                     loading={loading}
                 ></ConversationMessageList>
 
-                <Input.Group compact>
+                <Space.Compact
+                    style={{ width: '100%', justifyContent: 'center' }}
+                >
                     <Input
                         value={messageInput}
                         onChange={(x) => setMessageInput(x.target.value)}
@@ -142,7 +144,7 @@ const ChatLayout = () => {
                     <Button type="primary" onClick={sendMessage}>
                         <SendOutlined />
                     </Button>
-                </Input.Group>
+                </Space.Compact>
                 <Radio.Group
                     value={theme || 'light'}
                     onChange={(e) =>

--- a/chat-app-front/src/components/themes/CompactTheme.tsx
+++ b/chat-app-front/src/components/themes/CompactTheme.tsx
@@ -1,3 +1,0 @@
-import 'antd/dist/antd.compact.css';
-const CompactTheme = () => <></>;
-export default CompactTheme;

--- a/chat-app-front/src/components/themes/DarkTheme.tsx
+++ b/chat-app-front/src/components/themes/DarkTheme.tsx
@@ -1,3 +1,0 @@
-import 'antd/dist/antd.dark.css';
-const DarkTheme = () => <></>;
-export default DarkTheme;

--- a/chat-app-front/src/components/themes/LightTheme.tsx
+++ b/chat-app-front/src/components/themes/LightTheme.tsx
@@ -1,3 +1,0 @@
-import 'antd/dist/antd.css';
-const LightTheme = () => <></>;
-export default LightTheme;

--- a/chat-app-front/src/components/themes/ThemeProvider.tsx
+++ b/chat-app-front/src/components/themes/ThemeProvider.tsx
@@ -1,8 +1,6 @@
-import { createContext, lazy, ReactNode, Suspense } from 'react';
-
-const CompactTheme = lazy(() => import('./CompactTheme'));
-const DarkTheme = lazy(() => import('./DarkTheme'));
-const LightTheme = lazy(() => import('./LightTheme'));
+import { createContext, ReactNode } from 'react';
+import { ConfigProvider, theme } from 'antd';
+import 'antd/dist/reset.css';
 
 export const ThemeContext = createContext<{
     theme?: string;
@@ -10,28 +8,36 @@ export const ThemeContext = createContext<{
 }>({});
 
 const ThemeProvider = ({ children }: { children: ReactNode }) => {
-    const theme = localStorage.getItem('theme') || 'light';
+    const currentTheme = localStorage.getItem('theme') || 'light';
 
     const changeTheme = (newTheme: string) => {
         localStorage.setItem('theme', newTheme);
         window.location.reload();
     };
 
+    const getThemeConfig = () => {
+        switch (currentTheme) {
+            case 'dark':
+                return {
+                    algorithm: theme.darkAlgorithm,
+                };
+            case 'compact':
+                return {
+                    algorithm: theme.compactAlgorithm,
+                };
+            default:
+                return {
+                    algorithm: theme.defaultAlgorithm,
+                };
+        }
+    };
+
     return (
-        <>
-            <Suspense fallback={<span />}>
-                {theme === 'compact' ? (
-                    <CompactTheme />
-                ) : theme === 'dark' ? (
-                    <DarkTheme />
-                ) : (
-                    <LightTheme />
-                )}
-                <ThemeContext.Provider value={{ theme, changeTheme }}>
-                    {children}
-                </ThemeContext.Provider>
-            </Suspense>
-        </>
+        <ConfigProvider theme={getThemeConfig()}>
+            <ThemeContext.Provider value={{ theme: currentTheme, changeTheme }}>
+                {children}
+            </ThemeContext.Provider>
+        </ConfigProvider>
     );
 };
 


### PR DESCRIPTION
## Summary
- Upgrades Ant Design from v4.21.7 to v5.27.3 addressing GitHub issue #3
- Updates @ant-design/icons from v4.7.0 to v6.0.1
- Implements proper v5 theming system using ConfigProvider

## Changes Made
- **Dependencies**: Updated package.json with latest major versions
- **Theming**: Replaced CSS file imports with ConfigProvider and theme algorithms
- **Components**: Updated Input.Group compact to Space.Compact for v5 compatibility
- **Cleanup**: Removed unused individual theme component files

## Breaking Changes Addressed
- Removed external CSS imports as v5 uses CSS-in-JS with ConfigProvider
- Updated compact input group to use Space.Compact API
- Migrated from file-based theming to algorithm-based theming

## Validation
- ✅ Build passes without errors
- ✅ All linting checks pass  
- ✅ Development server runs cleanly
- ✅ All UI components render correctly
- ✅ Theme switching (light/dark/compact) works properly

## Test plan
- [x] Verify build completes successfully
- [x] Test development server starts without errors
- [x] Validate all Ant Design components render correctly
- [x] Test theme switching functionality
- [x] Run linting and ensure no errors

🤖 Generated with [Claude Code](https://claude.ai/code)