### PR TITLE
Add environment variable handling to chat-app-auth

### DIFF
--- a/chat-app-auth/.env.development.example
+++ b/chat-app-auth/.env.development.example
@@ -1,0 +1,6 @@
+# Development environment variables for chat-app-auth
+# Copy this file to .env.development.local and customize values
+
+PORT=8084
+NODE_ENV=development
+SESSION_SECRET=change-me-in-local-file

--- a/chat-app-auth/.env.production.example
+++ b/chat-app-auth/.env.production.example
@@ -1,0 +1,6 @@
+# Production environment variables for chat-app-auth
+# Copy this file to .env.production.local and customize values
+
+PORT=8084
+NODE_ENV=production
+SESSION_SECRET=your-secure-random-session-secret-here

--- a/chat-app-auth/.gitignore
+++ b/chat-app-auth/.gitignore
@@ -1,0 +1,29 @@
+# Dependencies
+node_modules/
+
+# Environment files
+.env.local
+.env.development.local
+.env.production.local
+
+# Build outputs
+dist/
+
+# Logs
+*.log
+
+# Runtime data
+pids
+*.pid
+*.seed
+
+# Coverage directory used by tools like istanbul
+coverage/
+
+# IDE
+.vscode/
+.idea/
+
+# OS
+.DS_Store
+Thumbs.db

--- a/chat-app-auth/src/index.ts
+++ b/chat-app-auth/src/index.ts
@@ -21,11 +21,19 @@ const app = express();
 /**
  * Express configuration.
  */
-app.set('port', 8084);
+const port = process.env['PORT'] || 8084;
+const sessionSecret = process.env['SESSION_SECRET'];
+
+if (!sessionSecret) {
+    console.error('SESSION_SECRET environment variable is required');
+    process.exit(1);
+}
+
+app.set('port', port);
 app.set('json spaces', 2); // number of spaces for indentation
 app.use(bodyParser.json());
 app.use(session({
-    secret: 'SECRET', 
+    secret: sessionSecret, 
     resave: true, 
     saveUninitialized: true
 }));

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -19,6 +19,8 @@ services:
             dockerfile: Dockerfile.prod
         depends_on:
             - "chat-app-prod-db"
+        env_file:
+            - ./chat-app-auth/.env.production.local
         environment:
             DATABASE_URL: postgres://chatapp:chatapp@chat-app-prod-db:5432/chatapp
         volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,6 +17,8 @@ services:
         restart: unless-stopped
         depends_on:
             - "chat-app-db"
+        env_file:
+            - ./chat-app-auth/.env.development.local
         environment:
             DATABASE_URL: postgres://chatapp:chatapp@chat-app-db:5432/chatapp
         volumes:


### PR DESCRIPTION
## Summary
- Replace hardcoded port and session secret with environment variables in `chat-app-auth/src/index.ts`
- Add validation for required `SESSION_SECRET` environment variable
- Create `.env.development.example` and `.env.production.example` template files
- Update Docker Compose files to use `env_file` configuration
- Add `.gitignore` to exclude local environment files

## Test plan
- [x] Service starts successfully when `SESSION_SECRET` is provided
- [x] Service exits with error when `SESSION_SECRET` is missing  
- [x] TypeScript builds without compilation errors
- [x] Docker Compose configuration updated for both development and production

🤖 Generated with [Claude Code](https://claude.ai/code)